### PR TITLE
SQ-716: Setup GH Actions to build and push DivBase images to GHCR

### DIFF
--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -1,0 +1,74 @@
+name: Build and Push images to GitHub Container Registry
+# The logic for settings Docker image tags is in ./scripts/ci/set_docker_tag.sh
+
+on:
+  push:
+    # Tag = commit hash
+    branches:
+      - main 
+    paths-ignore:
+      - 'README.md'
+      - 'docs/**'
+      - '.gitignore'
+      - '.dockerignore'
+  release:
+    # Tag = release version
+    types: [published]
+  workflow_dispatch:
+    # Tag = commit hash or custom tag set when manually triggering the GH action
+    inputs:
+      docker_tag:
+        description: 'Docker image tag (default: full commit hash)'
+        required: false
+
+jobs:
+  push-to-container-registry:
+    if: github.repository == 'ScilifelabDataCentre/divbase'  
+    name: Build and push DivBase images GitHub Container Registry
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    defaults:
+      run:
+        working-directory: ./scripts/ci
+
+    strategy:
+      matrix:
+        include:
+          - dockerfile: fastapi.dockerfile
+            image_name: divbase-fastapi
+          - dockerfile: flower.dockerfile
+            image_name: divbase-flower
+          - dockerfile: worker.dockerfile
+            image_name: divbase-worker
+            
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Set Docker tag
+        id: set-tag
+        run: |
+          ./set_docker_tag ${{ github.event_name }} \
+                           ${{ github.ref_name }} \
+                           ${{ github.sha }} \
+                           ${{ github.event.inputs.docker_tag }} \
+                           >> $GITHUB_OUTPUT
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+            push: ${{ github.event_name != 'pull_request' }}
+            context: .
+            file: ./docker/${{ matrix.dockerfile }}
+            tags: |
+                ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}:${{ steps.set-tag.outputs.tag }}
+                ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}:latest

--- a/scripts/ci/set_docker_tag.sh
+++ b/scripts/ci/set_docker_tag.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Note: using getopts here could be a awkward as DOCKER_TAG sometimes exists, sometimes doesn't.
+# DOCKER_TAG occurs if triggered by workflow_dispatch and tag added.
+
+EVENT_NAME=$1
+REF_NAME=$2
+SHA=$3
+DOCKER_TAG=$4
+
+
+if [ "$EVENT_NAME" = "release" ]; then
+    tag="$REF_NAME"
+else
+    tag="${DOCKER_TAG:-$SHA}"
+fi
+echo "tag=$tag"


### PR DESCRIPTION
This PR is about configuring a GitHub Actions workflow to publish Docker images to GitHub Container Registry. It is based on the corresponding code used in the [Swedish Reference Genome Portal](https://github.com/ScilifelabDataCentre/genome-portal) and adopted to DivBase. 

Like in the other repo, I kept it so that the action is triggered: on push to main (but not PR merge to main), on release, and on manual dispatch. That sounded reasonable to me, but am happy to discuss any other strategy.

The workflow currently builds three custom images: fastapi, flower, and worker. I deliberately skipped the benchmarking image for now, but I plan to revisit it at a later stage.

Our current Docker Compose setup creates two different images for worker-quick and worker-long. However, since the only difference between the two is the arguments when spinning up the containers/pods, it should be enough to create a single worker image and use that for both "quick" and "long" in the Docker Compose and k8s deployment manifests. 