### PR TITLE
SQ868: Cron job to hard delete "expired" results files

### DIFF
--- a/packages/divbase-api/src/divbase_api/services/s3_client.py
+++ b/packages/divbase-api/src/divbase_api/services/s3_client.py
@@ -26,7 +26,10 @@ from divbase_lib.api_schemas.s3 import (
     RestoreObjectsResponse,
     SoftDeletedObjectDetails,
 )
-from divbase_lib.divbase_constants import S3_MULTIPART_CHUNK_SIZE, S3_MULTIPART_UPLOAD_THRESHOLD
+from divbase_lib.divbase_constants import (
+    S3_MULTIPART_CHUNK_SIZE,
+    S3_MULTIPART_UPLOAD_THRESHOLD,
+)
 from divbase_lib.exceptions import ChecksumVerificationError
 from divbase_lib.s3_checksums import verify_downloaded_checksum
 
@@ -451,6 +454,25 @@ class S3FileManager:
                         continue
                     expired_objects.add(object_key)
         return expired_objects
+
+    def get_outdated_files(self, bucket_name: str, cutoff: datetime, prefix: str | None = None) -> list[dict[str, str]]:
+        """
+        Identify files that are older than the provided threshold date time.
+
+        Returns a list of objects in the format required by fn hard_delete_specific_object_versions:
+        [{"Key": "result_of_job_9.vcf.gz", "VersionId": "version-id"}, ...]
+        """
+        outdated_files = []
+        paginator = self.s3_client.get_paginator("list_object_versions")
+        args = {"Bucket": bucket_name}
+        if prefix:
+            args["Prefix"] = prefix
+
+        for page in paginator.paginate(**args):
+            for obj in page.get("Versions", []):
+                if obj["LastModified"] < cutoff:
+                    outdated_files.append({"Key": obj["Key"], "VersionId": obj["VersionId"]})
+        return outdated_files
 
     def get_bucket_usage_bytes(self, bucket_name: str) -> int:
         """

--- a/packages/divbase-api/src/divbase_api/worker/cron_tasks.py
+++ b/packages/divbase-api/src/divbase_api/worker/cron_tasks.py
@@ -45,20 +45,23 @@ def cleanup_old_task_history_task(retention_days: int = TASK_RETENTION_DAYS):
 
     with SyncSessionLocal() as db:
         # used for deleting from S3
-        stmt = select(ProjectDB.bucket_name).where(ProjectDB.is_active.is_(True))
-        bucket_names = db.execute(stmt).scalars().all()
+        bucket_names = db.execute(select(ProjectDB.bucket_name)).scalars().all()
 
-        old_task_ids = [
-            row[0]
-            for row in db.execute(
-                text("SELECT task_id FROM task_history WHERE created_at < :cutoff_date"),
-                {"cutoff_date": cutoff_date},
-            ).fetchall()
-        ]
+        stmt = select(TaskHistoryDB.task_id).where(TaskHistoryDB.created_at < cutoff_date)
+        old_task_ids = db.execute(stmt).scalars().all()
+
         deleted_celery_task_meta = db.execute(
             delete(CeleryTaskMeta).where(CeleryTaskMeta.task_id.in_(old_task_ids))
         ).rowcount
         deleted_task_history = db.execute(delete(TaskHistoryDB).where(TaskHistoryDB.task_id.in_(old_task_ids))).rowcount
+        # to catch case where no task_id added to db entry, as is nullable.
+        deleted_task_history_no_task_id = db.execute(
+            delete(TaskHistoryDB).where(
+                TaskHistoryDB.task_id.is_(None),
+                TaskHistoryDB.created_at < cutoff_date,
+            )
+        ).rowcount
+
         deleted_started_at = db.execute(
             delete(TaskStartedAtDB).where(TaskStartedAtDB.task_id.in_(old_task_ids))
         ).rowcount
@@ -84,6 +87,7 @@ def cleanup_old_task_history_task(retention_days: int = TASK_RETENTION_DAYS):
     logger.info(
         f"Cleaned up {deleted_celery_task_meta} entries from CeleryTaskMeta, "
         f"{deleted_task_history} from TaskHistoryDB, and "
+        f"{deleted_task_history_no_task_id} entries with no task_id from TaskHistoryDB, and "
         f"{deleted_started_at} from TaskStartedAtDB older than {retention_days} days "
         f"Hard deleted {total_results_files_deleted} query result files from {len(bucket_names)} S3 buckets. "
         f"(cutoff: {cutoff_date.isoformat()})"
@@ -93,6 +97,7 @@ def cleanup_old_task_history_task(retention_days: int = TASK_RETENTION_DAYS):
         "status": "completed",
         "number_of_celery_meta_deleted": deleted_celery_task_meta,
         "number_of_task_history_deleted": deleted_task_history,
+        "number_of_task_history_no_task_id_deleted": deleted_task_history_no_task_id,
         "number_of_started_at_deleted": deleted_started_at,
         "number_of_result_files_hard_deleted": total_results_files_deleted,
         "cutoff_date": cutoff_date.isoformat(),

--- a/packages/divbase-api/src/divbase_api/worker/cron_tasks.py
+++ b/packages/divbase-api/src/divbase_api/worker/cron_tasks.py
@@ -34,52 +34,70 @@ REVOKED_TOKEN_MAX_AGE_DAYS = 7
 @app.task(name="cron_tasks.cleanup_old_task_history")
 def cleanup_old_task_history_task(retention_days: int = TASK_RETENTION_DAYS):
     """
-    Periodic task to clean up old task history entries from both TaskHistoryDB and CeleryTaskMeta.
+    Periodic task to clean up old task entries:
+    Removes:
+    1. Entries from both TaskHistoryDB, TaskStartedAtDB and CeleryTaskMeta.
+    2. Query result files from S3 that are associated with those tasks (hard delete of the files).
+
     Runs daily to remove entries older than retention_days.
     """
-    try:
-        cutoff_date = datetime.now(timezone.utc) - timedelta(days=retention_days)
+    cutoff_date = datetime.now(timezone.utc) - timedelta(days=retention_days)
 
-        with SyncSessionLocal() as db:
-            old_task_ids = [
-                row[0]
-                for row in db.execute(
-                    text("SELECT task_id FROM task_history WHERE created_at < :cutoff_date"),
-                    {"cutoff_date": cutoff_date},
-                ).fetchall()
-            ]
+    with SyncSessionLocal() as db:
+        # used for deleting from S3
+        stmt = select(ProjectDB.bucket_name).where(ProjectDB.is_active.is_(True))
+        bucket_names = db.execute(stmt).scalars().all()
 
-            deleted_celery_task_meta = db.execute(
-                delete(CeleryTaskMeta).where(CeleryTaskMeta.task_id.in_(old_task_ids))
-            ).rowcount
-            deleted_task_history = db.execute(
-                delete(TaskHistoryDB).where(TaskHistoryDB.task_id.in_(old_task_ids))
-            ).rowcount
-            deleted_started_at = db.execute(
-                delete(TaskStartedAtDB).where(TaskStartedAtDB.task_id.in_(old_task_ids))
-            ).rowcount
+        old_task_ids = [
+            row[0]
+            for row in db.execute(
+                text("SELECT task_id FROM task_history WHERE created_at < :cutoff_date"),
+                {"cutoff_date": cutoff_date},
+            ).fetchall()
+        ]
+        deleted_celery_task_meta = db.execute(
+            delete(CeleryTaskMeta).where(CeleryTaskMeta.task_id.in_(old_task_ids))
+        ).rowcount
+        deleted_task_history = db.execute(delete(TaskHistoryDB).where(TaskHistoryDB.task_id.in_(old_task_ids))).rowcount
+        deleted_started_at = db.execute(
+            delete(TaskStartedAtDB).where(TaskStartedAtDB.task_id.in_(old_task_ids))
+        ).rowcount
 
-            db.commit()
+        db.commit()
 
-            logger.info(
-                f"Cleaned up {deleted_celery_task_meta} entries from CeleryTaskMeta, "
-                f"{deleted_task_history} from TaskHistoryDB, and "
-                f"{deleted_started_at} from TaskStartedAtDB older than {retention_days} days "
-                f"(cutoff: {cutoff_date.isoformat()})"
+    # removing query results files from S3
+    s3_file_manager = create_s3_file_manager(url=S3_ENDPOINT_URL)
+    total_results_files_deleted = 0
+    for bucket in bucket_names:
+        objects_to_delete = s3_file_manager.get_outdated_files(
+            bucket_name=bucket,
+            cutoff=cutoff_date,
+            prefix=QUERY_RESULTS_FILE_PREFIX,
+        )
+        if objects_to_delete:
+            s3_file_manager.hard_delete_specific_object_versions(
+                objects=objects_to_delete,
+                bucket_name=bucket,
             )
+            total_results_files_deleted += len(objects_to_delete)
 
-            return {
-                "status": "completed",
-                "number_of_celery_meta_deleted": deleted_celery_task_meta,
-                "number_of_task_history_deleted": deleted_task_history,
-                "number_of_started_at_deleted": deleted_started_at,
-                "cutoff_date": cutoff_date.isoformat(),
-                "retention_days": retention_days,
-            }
+    logger.info(
+        f"Cleaned up {deleted_celery_task_meta} entries from CeleryTaskMeta, "
+        f"{deleted_task_history} from TaskHistoryDB, and "
+        f"{deleted_started_at} from TaskStartedAtDB older than {retention_days} days "
+        f"Hard deleted {total_results_files_deleted} query result files from {len(bucket_names)} S3 buckets. "
+        f"(cutoff: {cutoff_date.isoformat()})"
+    )
 
-    except Exception as e:
-        logger.error(f"Failed to cleanup old task history: {e}")
-        raise
+    return {
+        "status": "completed",
+        "number_of_celery_meta_deleted": deleted_celery_task_meta,
+        "number_of_task_history_deleted": deleted_task_history,
+        "number_of_started_at_deleted": deleted_started_at,
+        "number_of_result_files_hard_deleted": total_results_files_deleted,
+        "cutoff_date": cutoff_date.isoformat(),
+        "retention_days": retention_days,
+    }
 
 
 @app.task(name="cron_tasks.cleanup_stuck_tasks")

--- a/tests/e2e_integration/cli_commands/test_file_cli.py
+++ b/tests/e2e_integration/cli_commands/test_file_cli.py
@@ -12,7 +12,6 @@ import shutil
 from io import StringIO
 from pathlib import Path
 
-import boto3
 import pytest
 from typer.testing import CliRunner
 
@@ -35,34 +34,6 @@ runner = CliRunner()
 # This is the maximum number of objects S3 will allow in a single call.
 # So pagination can be validated to be working for any files cmd if use more than this number of files
 S3_PAGINATION_LIMIT = 1000
-
-
-@pytest.fixture(autouse=True)
-def start_with_clean_project(CONSTANTS):
-    """
-    For tests that require a project with a clean bucket, this fixture will
-    ensure that the CONSTANTS["CLEANED_PROJECT"]'s bucket is empty before and after running the test.
-
-    Caution:
-    If you modify the approach make sure your implementation does not just add delete markers.
-    The files need to be actually deleted.
-    """
-    s3_resource = boto3.resource(
-        "s3",
-        endpoint_url=CONSTANTS["MINIO_URL"],
-        aws_access_key_id=CONSTANTS["BAD_ACCESS_KEY"],
-        aws_secret_access_key=CONSTANTS["BAD_SECRET_KEY"],
-    )
-    # pylance does not understand boto3 resource returns types, hence ignore below
-    cleaned_project_bucket_name = CONSTANTS["PROJECT_TO_BUCKET_MAP"][CONSTANTS["CLEANED_PROJECT"]]
-
-    bucket = s3_resource.Bucket(cleaned_project_bucket_name)  # type: ignore
-    bucket.object_versions.delete()
-
-    yield
-
-    bucket = s3_resource.Bucket(cleaned_project_bucket_name)  # type: ignore
-    bucket.object_versions.delete()
 
 
 @pytest.fixture(scope="module")

--- a/tests/e2e_integration/conftest.py
+++ b/tests/e2e_integration/conftest.py
@@ -8,6 +8,7 @@ It also collects fixtures and constants that are needed across multiple test mod
 import logging
 from unittest.mock import patch
 
+import boto3
 import pytest
 from typer.testing import CliRunner
 
@@ -178,3 +179,31 @@ def clean_all_projects_dimensions(clean_vcf_dimensions, db_session_sync, project
     for project_id in project_map.values():
         clean_vcf_dimensions(db_session_sync, project_id)
     yield
+
+
+@pytest.fixture(autouse=True)
+def start_with_clean_project(CONSTANTS):
+    """
+    For tests that require a project with a clean bucket, this fixture will
+    ensure that the CONSTANTS["CLEANED_PROJECT"]'s bucket is empty before and after running the test.
+
+    Caution:
+    If you modify the approach make sure your implementation does not just add delete markers.
+    The files need to be actually deleted.
+    """
+    s3_resource = boto3.resource(
+        "s3",
+        endpoint_url=CONSTANTS["MINIO_URL"],
+        aws_access_key_id=CONSTANTS["BAD_ACCESS_KEY"],
+        aws_secret_access_key=CONSTANTS["BAD_SECRET_KEY"],
+    )
+    # pylance does not understand boto3 resource returns types, hence ignore below
+    cleaned_project_bucket_name = CONSTANTS["PROJECT_TO_BUCKET_MAP"][CONSTANTS["CLEANED_PROJECT"]]
+
+    bucket = s3_resource.Bucket(cleaned_project_bucket_name)  # type: ignore
+    bucket.object_versions.delete()
+
+    yield
+
+    bucket = s3_resource.Bucket(cleaned_project_bucket_name)  # type: ignore
+    bucket.object_versions.delete()

--- a/tests/e2e_integration/test_cron_tasks.py
+++ b/tests/e2e_integration/test_cron_tasks.py
@@ -27,6 +27,7 @@ from divbase_api.security import TokenType
 from divbase_api.services.s3_client import S3FileManager, create_s3_file_manager
 from divbase_api.worker.cron_tasks import (
     SOFT_DELETED_FILES_RETENTION_DAYS,
+    TASK_RETENTION_DAYS,
     cleanup_old_revoked_tokens,
     cleanup_old_task_history_task,
     cleanup_soft_deleted_project_versions,
@@ -34,6 +35,7 @@ from divbase_api.worker.cron_tasks import (
     hard_delete_expired_soft_deleted_objects,
     update_storage_usage_metrics,
 )
+from divbase_lib.divbase_constants import QUERY_RESULTS_FILE_PREFIX
 
 
 class TaskStatus(StrEnum):
@@ -148,6 +150,7 @@ def s3_file_manager(CONSTANTS) -> S3FileManager:
 def test_cleanup_old_task_history_deletes_entries_older_than_threshold(
     db_session_sync,
     create_task_entry,
+    CONSTANTS,
 ):
     """
     Test that cleanup_old_task_history_task deletes entries older than retention period
@@ -163,7 +166,8 @@ def test_cleanup_old_task_history_deletes_entries_older_than_threshold(
     recent_task_id_10days = create_task_entry(time_old=10, status=TaskStatus.SUCCESS)
     recent_task_id_25days = create_task_entry(time_old=25, status=TaskStatus.SUCCESS)
 
-    result = cleanup_old_task_history_task(retention_days=retention_days)
+    with patch("divbase_api.worker.cron_tasks.S3_ENDPOINT_URL", CONSTANTS["MINIO_URL"]):
+        result = cleanup_old_task_history_task(retention_days=retention_days)
 
     assert result["status"] == "completed"
     assert result["number_of_celery_meta_deleted"] == 2
@@ -193,7 +197,7 @@ def test_cleanup_old_task_history_deletes_entries_older_than_threshold(
         assert celery_meta is not None, f"Task {task_id} should have been kept in CeleryTaskMeta"
 
 
-def test_cleanup_old_task_history_with_no_old_entries(db_session_sync, create_task_entry):
+def test_cleanup_old_task_history_with_no_old_entries(create_task_entry, CONSTANTS):
     """
     Test that cleanup task handles the case where there are no old entries gracefully.
     """
@@ -202,14 +206,15 @@ def test_cleanup_old_task_history_with_no_old_entries(db_session_sync, create_ta
     create_task_entry(time_old=5, status=TaskStatus.SUCCESS)
     create_task_entry(time_old=15, status=TaskStatus.SUCCESS)
 
-    result = cleanup_old_task_history_task(retention_days=retention_days)
+    with patch("divbase_api.worker.cron_tasks.S3_ENDPOINT_URL", CONSTANTS["MINIO_URL"]):
+        result = cleanup_old_task_history_task(retention_days=retention_days)
 
     assert result["status"] == "completed"
     assert result["number_of_celery_meta_deleted"] == 0
     assert result["number_of_task_history_deleted"] == 0
 
 
-def test_cleanup_old_task_history_with_system_tasks(db_session_sync, create_task_entry):
+def test_cleanup_old_task_history_with_system_tasks(db_session_sync, create_task_entry, CONSTANTS):
     """
     Test that cleanup works correctly for system tasks (project_id=NULL).
     """
@@ -222,7 +227,8 @@ def test_cleanup_old_task_history_with_system_tasks(db_session_sync, create_task
         user_id=2,
     )
 
-    result = cleanup_old_task_history_task(retention_days=retention_days)
+    with patch("divbase_api.worker.cron_tasks.S3_ENDPOINT_URL", CONSTANTS["MINIO_URL"]):
+        result = cleanup_old_task_history_task(retention_days=retention_days)
 
     assert result["status"] == "completed"
     assert result["number_of_task_history_deleted"] >= 1
@@ -237,6 +243,70 @@ def test_cleanup_old_task_history_with_system_tasks(db_session_sync, create_task
         select(CeleryTaskMeta).where(CeleryTaskMeta.task_id == system_task_id)
     ).scalar_one_or_none()
     assert celery_meta is None
+
+
+@pytest.mark.parametrize(
+    "days_offset,expect_deleted",
+    [
+        (TASK_RETENTION_DAYS + 1, True),
+        (TASK_RETENTION_DAYS - 1, False),
+    ],
+)
+def test_cleanup_old_task_history_deletes_result_files_from_s3(
+    s3_file_manager: S3FileManager,
+    project_map: dict,
+    CONSTANTS: dict,
+    tmp_path: Path,
+    days_offset: int,
+    expect_deleted: bool,
+):
+    """
+    Test that cleanup_old_task_history_task hard deletes query result files from S3
+    when they are older than the retention period, and leaves them untouched when within it.
+
+    Worker pretends we are days_offset days in the future so the task's cutoff_date shifts
+    accordingly relative to the file's upload timestamp.
+    """
+    project_name = CONSTANTS["CLEANED_PROJECT"]
+    bucket_name = CONSTANTS["PROJECT_TO_BUCKET_MAP"][project_name]
+
+    # Upload some fake results files.
+    job_ids = [3, 5, 100, 299, 10000]
+
+    to_upload = {}
+    for i in job_ids:
+        result_file = tmp_path / f"{QUERY_RESULTS_FILE_PREFIX}{i}.vcf.gz"
+        result_file.write_text("fake query result content")
+        to_upload[result_file.name] = result_file
+
+    s3_file_manager.upload_files(bucket_name=bucket_name, to_upload=to_upload)
+
+    # Pretend we are days_offset days in the future so the cutoff shifts forward
+    mocked_now = datetime.now(timezone.utc) + timedelta(days=days_offset)
+    with (
+        patch("divbase_api.worker.cron_tasks.datetime") as mock_datetime_cron,
+        patch("divbase_api.worker.cron_tasks.S3_ENDPOINT_URL", CONSTANTS["MINIO_URL"]),
+    ):
+        mock_datetime_cron.now.return_value = mocked_now
+        result = cleanup_old_task_history_task(retention_days=TASK_RETENTION_DAYS)
+
+    assert result["status"] == "completed"
+    if expect_deleted:
+        # we could delete results files from prior tests that do not clean up those files, hence the >=
+        assert result["number_of_result_files_hard_deleted"] >= len(job_ids)
+    else:
+        assert result["number_of_result_files_hard_deleted"] == 0
+
+    bucket_status = s3_file_manager.s3_client.list_object_versions(Bucket=bucket_name, Prefix=QUERY_RESULTS_FILE_PREFIX)
+
+    for i in job_ids:
+        result_file_name = f"{QUERY_RESULTS_FILE_PREFIX}{i}.vcf.gz"
+        file_exists = any(v["Key"] == result_file_name for v in bucket_status.get("Versions", []))
+
+        if expect_deleted:
+            assert not file_exists, f"{result_file_name} should have been hard-deleted from S3"
+        else:
+            assert file_exists, f"{result_file_name} should NOT have been deleted from S3"
 
 
 def test_cleanup_stuck_tasks_removes_pending_and_started(db_session_sync, create_task_entry):

--- a/tests/unit/divbase_api/test_cron_tasks.py
+++ b/tests/unit/divbase_api/test_cron_tasks.py
@@ -32,7 +32,7 @@ def test_cleanup_old_task_history_deletes_old_entries(mock_db_session):
         assert result["number_of_celery_meta_deleted"] == 5
         assert result["number_of_task_history_deleted"] == 5
         assert result["retention_days"] == 30
-        assert mock_db_session.execute.call_count == 4
+        assert mock_db_session.execute.call_count == 5
         assert mock_db_session.commit.called
 
 

--- a/tests/unit/divbase_api/test_cron_tasks.py
+++ b/tests/unit/divbase_api/test_cron_tasks.py
@@ -32,7 +32,7 @@ def test_cleanup_old_task_history_deletes_old_entries(mock_db_session):
         assert result["number_of_celery_meta_deleted"] == 5
         assert result["number_of_task_history_deleted"] == 5
         assert result["retention_days"] == 30
-        assert mock_db_session.execute.call_count == 5
+        assert mock_db_session.execute.call_count == 6
         assert mock_db_session.commit.called
 
 


### PR DESCRIPTION
This PR adds in the missing cron functionality to hard delete "expired" (older than 30 days) query results file from S3, with this being included in the same job that deletes these jobs/tasks entries in the db - as planned. 

Also included in this PR is an update to the e2e tests to validate this works as expected. This required moving the fixture to create a "clean bucket" (empties a specific bucket before and after each test) to the top `conftest.py`, so these could be made use of by these tests.  

Will take a review from the :robot: first. 