### PR TITLE
SQ:894: Docker use uv instead of pip to install api and worker

### DIFF
--- a/docker/divbase_compose.yaml
+++ b/docker/divbase_compose.yaml
@@ -65,10 +65,10 @@ services:
       watch:
         - action: sync+restart
           path: ../packages/divbase-api/src/divbase_api/
-          target: /usr/local/lib/python3.12/site-packages/divbase_api/
+          target: /app/.venv/lib/python3.13/site-packages/divbase_api/
         - action: sync+restart
           path: ../packages/divbase-lib/src/divbase_lib/
-          target: /usr/local/lib/python3.12/site-packages/divbase_lib/
+          target: /app/.venv/lib/python3.13/site-packages/divbase_lib/
         - action: rebuild
           path: ../uv.lock
     command: ["-Q", "quick,celery", "--hostname=worker-quick@%h", "--concurrency=1", "-B"] #-Q "celery" is the default queue, so let the quick worker also handle it to avoid issues with tasks not being picked up
@@ -148,15 +148,15 @@ services:
       dockerfile: docker/fastapi.dockerfile
     ports:
       - 8000:8000
-    command: ["fastapi", "dev", "--host", "0.0.0.0", "/usr/local/lib/python3.12/site-packages/divbase_api/divbase_api.py"]
+    command: ["fastapi", "dev", "--host", "0.0.0.0", "/app/.venv/lib/python3.13/site-packages/divbase_api/divbase_api.py"] 
     develop: # rebuild only on changes to deps. 
       watch:
         - action: sync+restart
           path: ../packages/divbase-api/src/divbase_api/
-          target: /usr/local/lib/python3.12/site-packages/divbase_api/
+          target: /app/.venv/lib/python3.13/site-packages/divbase_api/
         - action: sync+restart
           path: ../packages/divbase-lib/src/divbase_lib/
-          target: /usr/local/lib/python3.12/site-packages/divbase_lib/
+          target: /app/.venv/lib/python3.13/site-packages/divbase_lib/
         - action: rebuild
           path: ../uv.lock
     volumes:

--- a/docker/fastapi.dockerfile
+++ b/docker/fastapi.dockerfile
@@ -1,30 +1,51 @@
 ## Stage 1: Build 
-FROM python:3.12.11-alpine3.22  AS builder
+FROM ghcr.io/astral-sh/uv:python3.13-alpine3.23 AS builder
+
+
+# UV_COMPILE_BYTECODE=1 Compile to bytecode during install so faster startup time
+# UV_LINK_MODE=copy recommended for docker 
+# UV_PYTHON_DOWNLOADS=0 use images python install 
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PYTHON_DOWNLOADS=0 
 
 WORKDIR /app
 
-RUN apk add --no-cache curl gcc g++ musl-dev && \
-    pip install --upgrade pip
+# This installs dependencies but not divbase packages so layer only invalidated when dependencies change, not source code
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=/app/uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=/app/pyproject.toml \
+    --mount=type=bind,source=packages/divbase-lib/pyproject.toml,target=/app/packages/divbase-lib/pyproject.toml \
+    --mount=type=bind,source=packages/divbase-api/pyproject.toml,target=/app/packages/divbase-api/pyproject.toml \
+    uv sync --frozen --no-dev --no-install-workspace --package divbase-api
 
-# Pip will complain if the readme is not copied over, since it is referenced in pyproject.toml 
-COPY README.md ./
-
-# Copy all package sources and install in dependency order
+# Copy source code and install workspace packages
+COPY README.md pyproject.toml uv.lock ./
 COPY packages/divbase-lib/ ./packages/divbase-lib/
-RUN pip install ./packages/divbase-lib/
 COPY packages/divbase-api/ ./packages/divbase-api/
-RUN pip install ./packages/divbase-api/
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-editable --package divbase-api
 
-## Stage 2: Final stage
-FROM python:3.12.11-alpine3.22 
+## Stage 2: Final image (without uv installed)
+FROM python:3.13-alpine3.23
 
 WORKDIR /app
 
-# curl is needed for healthchecks
+# curl needed for healthcheck
 RUN apk add --no-cache curl
 
-COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
-COPY --from=builder /usr/local/bin /usr/local/bin
+# Setup a non-root user
+RUN addgroup -g 1000 appuser && \
+    adduser -u 1000 -G appuser -s /bin/sh -D appuser && \
+    chown -R appuser:appuser /app
 
-# host needs to be set to 0.0.0.0 to be accessible from outside the container
-CMD ["fastapi", "run", "--host", "0.0.0.0", "/usr/local/lib/python3.12/site-packages/divbase_api/divbase_api.py"]
+COPY --from=builder --chown=appuser:appuser /app/.venv /app/.venv
+
+# PYTHONUNBUFFERED=1 allows for log messages to be sent immediately rather than buffered, can lose log message on application crash otherwise
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1
+
+USER appuser
+
+CMD ["fastapi", "run", "--host", "0.0.0.0", "/app/.venv/lib/python3.13/site-packages/divbase_api/divbase_api.py"]
+

--- a/docker/worker.dockerfile
+++ b/docker/worker.dockerfile
@@ -1,12 +1,15 @@
 ## Stage 1: Build
-FROM python:3.12.11-alpine3.22 AS builder
-
-WORKDIR /app
+FROM ghcr.io/astral-sh/uv:python3.13-alpine3.23 AS builder
 
 ARG BCFTOOLS_VERSION="1.22"
 
-RUN apk update && \
-    apk add --no-cache \
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PYTHON_DOWNLOADS=0
+
+WORKDIR /app
+
+RUN apk add --no-cache \
     gcc \
     musl-dev \
     python3-dev \
@@ -26,21 +29,25 @@ RUN curl -fsSL https://github.com/samtools/bcftools/releases/download/${BCFTOOLS
     && cd /tmp/bcftools-${BCFTOOLS_VERSION} \
     && make \
     && make install \
-    && cd - && rm -rf /tmp/bcftools-${BCFTOOLS_VERSION}  \
-    && pip install --upgrade pip
+    && rm -rf /tmp/bcftools-${BCFTOOLS_VERSION}
 
-# Pip will complain if the readme is not copied over, since it is referenced in pyproject.toml   
-COPY README.md ./
+# This installs dependencies but not divbase packages so layer only invalidated when dependencies change, not source code
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=/app/uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=/app/pyproject.toml \
+    --mount=type=bind,source=packages/divbase-lib/pyproject.toml,target=/app/packages/divbase-lib/pyproject.toml \
+    --mount=type=bind,source=packages/divbase-api/pyproject.toml,target=/app/packages/divbase-api/pyproject.toml \
+    uv sync --frozen --no-dev --no-install-workspace --package divbase-api
 
-# Copy all package sources and install in dependency order
+# Copy source code and install workspace packages
+COPY README.md pyproject.toml uv.lock ./
 COPY packages/divbase-lib/ ./packages/divbase-lib/
-RUN pip install ./packages/divbase-lib/
 COPY packages/divbase-api/ ./packages/divbase-api/
-RUN pip install ./packages/divbase-api/
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-editable --package divbase-api
 
-
-## Stage 2: Final image
-FROM python:3.12.11-alpine3.22
+## Stage 2: Final image (without uv installed)
+FROM python:3.13-alpine3.23
 
 WORKDIR /app
 
@@ -55,13 +62,17 @@ RUN apk add --no-cache \
     openssl \
     perl
 
-COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
-COPY --from=builder /usr/local/bin /usr/local/bin
-
-# Create a proper user and group to avoid Celery warnings. Write access to /app is needed for bcftools.
+# Setup a non-root user. Write access to /app is needed for bcftools.
 RUN addgroup -g 1000 appuser && \
     adduser -u 1000 -G appuser -s /bin/sh -D appuser && \
     chown -R appuser:appuser /app
+
+COPY --from=builder /usr/local/bin/bcftools /usr/local/bin/bcftools
+COPY --from=builder --chown=appuser:appuser /app/.venv /app/.venv
+
+# PYTHONUNBUFFERED=1 allows for log messages to be sent immediately rather than buffered, can lose log message on application crash otherwise
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1
 
 USER appuser
 


### PR DESCRIPTION
PR to modify the docker images to use uv over pip to install, which ensures we actually use the packages defined in the uv.lock file in our docker images.  

Took the liberty to bump python and alpine versions etc... too.

All tests pass and validated that the docker compose watch setup is working in that changes are indeed registered etc... 

Another nice thing is rebuilding the images (compose up/ initial compose watch) tends to be a lot faster due to separating the install of the dependencies from the install of the codebase.  

Given the prior docker + Mac issues etc.. it seems like a good idea for you to test this @brinkdp 

### Note: 
When merged and deployed, we will need to update the cmd used in the worker and api manifests in the argocd repo to use the new path to the application. 