### PR TITLE
SQ-896: Store user JWTs in OS keyring

### DIFF
--- a/packages/divbase-api/src/divbase_api/deps.py
+++ b/packages/divbase-api/src/divbase_api/deps.py
@@ -36,8 +36,9 @@ from divbase_api.db import get_db
 from divbase_api.exceptions import AuthenticationError, AuthorizationError
 from divbase_api.models.projects import ProjectDB, ProjectRoles
 from divbase_api.models.users import UserDB
-from divbase_api.security import PAT_TOKEN_PREFIX, TokenType, create_token
+from divbase_api.security import TokenType, create_token
 from divbase_lib.api_schemas.personal_access_tokens import PATPermissions
+from divbase_lib.divbase_constants import PAT_TOKEN_PREFIX
 
 logger = logging.getLogger(__name__)
 

--- a/packages/divbase-api/src/divbase_api/security.py
+++ b/packages/divbase-api/src/divbase_api/security.py
@@ -23,10 +23,9 @@ from pwdlib.hashers.argon2 import Argon2Hasher
 from pydantic import SecretStr
 
 from divbase_api.api_config import api_settings
+from divbase_lib.divbase_constants import PAT_TOKEN_PREFIX
 
 password_hash = PasswordHash(hashers=[Argon2Hasher()])
-
-PAT_TOKEN_PREFIX = "divbase_pat_"
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:

--- a/packages/divbase-cli/pyproject.toml
+++ b/packages/divbase-cli/pyproject.toml
@@ -9,7 +9,8 @@ authors = [
 requires-python = ">=3.12"
 dependencies = [
     "typer==0.24.1",
-    "divbase-lib==0.1.0.dev5"
+    "keyring>=25.7.0",
+    "divbase-lib==0.1.0.dev5",
 ]
 dynamic = ["version"]
 

--- a/packages/divbase-cli/src/divbase_cli/cli_config.py
+++ b/packages/divbase-cli/src/divbase_cli/cli_config.py
@@ -8,10 +8,11 @@ https://typer.tiangolo.com/tutorial/app-dir/
 """
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import typer
+from pydantic import SecretStr
 
 APP_NAME = "divbase-cli"
 APP_DIR = Path(typer.get_app_dir(APP_NAME))
@@ -41,12 +42,19 @@ class DivBaseCLISettings:
     CONFIG_PATH: Path = Path(os.getenv("DIVBASE_CLI_CONFIG_PATH", CONFIG_PATH))
     TOKENS_PATH: Path = Path(os.getenv("DIVBASE_CLI_TOKENS_PATH", TOKENS_PATH))
     DIVBASE_API_URL: str = os.getenv("DIVBASE_API_URL", DEFAULT_DIVBASE_API_URL)
-    DIVBASE_API_PAT: str | None = os.getenv("DIVBASE_API_PAT")
+
     METADATA_TSV_NAME: str = os.getenv("DIVBASE_METADATA_TSV_NAME", DEFAULT_METADATA_TSV_NAME)
     LOGGING_ON: bool = os.getenv("DIVBASE_LOGGING_ON", DEFAULT_LOGGING_ON) == "1"
     LOG_LEVEL: str = os.getenv("DIVBASE_LOG_LEVEL", DEFAULT_LOG_LEVEL).upper()
 
+    DIVBASE_API_PAT: SecretStr | None = field(init=False)
+
     def __post_init__(self):
+        if os.getenv("DIVBASE_API_PAT"):
+            self.DIVBASE_API_PAT = SecretStr(os.environ["DIVBASE_API_PAT"])
+        else:
+            self.DIVBASE_API_PAT = None
+
         valid_levels = ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"]
         if self.LOG_LEVEL not in valid_levels:
             raise ValueError(f"Invalid LOG_LEVEL: {self.LOG_LEVEL}. Must be one of {valid_levels}.")

--- a/packages/divbase-cli/src/divbase_cli/cli_config.py
+++ b/packages/divbase-cli/src/divbase_cli/cli_config.py
@@ -40,9 +40,14 @@ class DivBaseCLISettings:
     """
 
     CONFIG_PATH: Path = Path(os.getenv("DIVBASE_CLI_CONFIG_PATH", CONFIG_PATH))
-    TOKENS_PATH: Path = Path(os.getenv("DIVBASE_CLI_TOKENS_PATH", TOKENS_PATH))
-    DIVBASE_API_URL: str = os.getenv("DIVBASE_API_URL", DEFAULT_DIVBASE_API_URL)
 
+    # for tokens stored via OS keyring, we use these to define a unique lookup key.
+    KEYRING_SERVICE: str = os.getenv("DIVBASE_KEYRING_SERVICE", "divbase-cli")
+    KEYRING_USERNAME: str = "tokens"
+    # Fallback path for tokens storage if keyring cannot be used on device.
+    TOKENS_PATH: Path = Path(os.getenv("DIVBASE_CLI_TOKENS_PATH", TOKENS_PATH))
+
+    DIVBASE_API_URL: str = os.getenv("DIVBASE_API_URL", DEFAULT_DIVBASE_API_URL)
     METADATA_TSV_NAME: str = os.getenv("DIVBASE_METADATA_TSV_NAME", DEFAULT_METADATA_TSV_NAME)
     LOGGING_ON: bool = os.getenv("DIVBASE_LOGGING_ON", DEFAULT_LOGGING_ON) == "1"
     LOG_LEVEL: str = os.getenv("DIVBASE_LOG_LEVEL", DEFAULT_LOG_LEVEL).upper()

--- a/packages/divbase-cli/src/divbase_cli/user_auth.py
+++ b/packages/divbase-cli/src/divbase_cli/user_auth.py
@@ -11,7 +11,6 @@ import contextlib
 import json
 import logging
 import os
-import stat
 import time
 import warnings
 from dataclasses import dataclass
@@ -68,10 +67,11 @@ class TokenData:
             logger.debug(f"Keyring JWT storage failed with error: {e}\n falling back to file storage.")
 
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(output_path, "w") as file:
+        # Create file with 0600 permissions (user read/write only).
+        # Windows doesn't support 0600 permissions, but Windows can use keyring.
+        fd = os.open(path=output_path, flags=os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode=0o600)
+        with os.fdopen(fd, "w") as file:
             yaml.safe_dump(token_dict, file, sort_keys=False)
-        # only user has read and write permissions for tokens (0600)
-        os.chmod(path=output_path, mode=stat.S_IRUSR | stat.S_IWUSR)
 
     def is_access_token_expired(self) -> bool:
         """Check if the access token is expired"""

--- a/packages/divbase-cli/src/divbase_cli/user_auth.py
+++ b/packages/divbase-cli/src/divbase_cli/user_auth.py
@@ -1,10 +1,17 @@
 """
 Manage user authentication with the DivBase server.
 
-This includes login/logout and the getting, storing, using, and refreshing of access + refresh tokens
+This includes login/logout and the getting, storing, using, and refreshing of access + refresh JWTs and Personal Access Tokens (PATs).
+
+User JWTs are stored in the devices's OS keyring. They fallback to a local file with 0600 permissions if not possible.
+PATS provided via enviroment variable
 """
 
+import contextlib
+import json
 import logging
+import os
+import stat
 import time
 import warnings
 from dataclasses import dataclass
@@ -12,8 +19,10 @@ from json import JSONDecodeError
 from pathlib import Path
 
 import httpx
+import keyring
 import stamina
 import yaml
+from keyring.errors import KeyringError, NoKeyringError, PasswordDeleteError
 from pydantic import SecretStr
 
 from divbase_cli import __version__ as cli_version
@@ -31,9 +40,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class TokenData:
-    """
-    Class to hold user token information.
-    """
+    """Class to hold user JWT data"""
 
     access_token: SecretStr
     refresh_token: SecretStr
@@ -41,17 +48,30 @@ class TokenData:
     refresh_token_expires_at: int
 
     def dump_tokens(self, output_path: Path = cli_settings.TOKENS_PATH) -> None:
-        """Dump the user token data to the specified output path"""
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-
+        """Dump the user token data to the OS keyring. If fails, fall back to a local file."""
         token_dict = {
             "access_token": self.access_token.get_secret_value(),
             "refresh_token": self.refresh_token.get_secret_value(),
             "access_token_expires_at": self.access_token_expires_at,
             "refresh_token_expires_at": self.refresh_token_expires_at,
         }
+        try:
+            keyring.set_password(
+                service_name=cli_settings.KEYRING_SERVICE,
+                username=cli_settings.KEYRING_USERNAME,
+                password=json.dumps(token_dict),
+            )
+            output_path.unlink(missing_ok=True)
+            logger.debug("JWTs stored in device keyring successfully.")
+            return
+        except KeyringError as e:
+            logger.debug(f"Keyring JWT storage failed with error: {e}\n falling back to file storage.")
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
         with open(output_path, "w") as file:
             yaml.safe_dump(token_dict, file, sort_keys=False)
+        # only user has read and write permissions for tokens (0600)
+        os.chmod(path=output_path, mode=stat.S_IRUSR | stat.S_IWUSR)
 
     def is_access_token_expired(self) -> bool:
         """Check if the access token is expired"""
@@ -60,6 +80,13 @@ class TokenData:
     def is_refresh_token_expired(self) -> bool:
         """Check if the refresh token is expired"""
         return time.time() >= (self.refresh_token_expires_at - 300)  # 5 minute buffer
+
+
+def _delete_stored_jwts(token_path: Path) -> None:
+    """Attempt to delete user JWTs from both the keyring and the fallback file."""
+    with contextlib.suppress(NoKeyringError, PasswordDeleteError):
+        keyring.delete_password(service_name=cli_settings.KEYRING_SERVICE, username=cli_settings.KEYRING_USERNAME)
+    token_path.unlink(missing_ok=True)
 
 
 def check_existing_session(divbase_url: str, config) -> int | None:
@@ -153,7 +180,7 @@ def logout_of_divbase(token_path: Path = cli_settings.TOKENS_PATH) -> None:
     if config.logged_in_url:
         token_data = load_user_tokens(token_path=token_path)
         if not token_data:
-            token_path.unlink(missing_ok=True)
+            _delete_stored_jwts(token_path)
             config.set_login_status(url=None, email=None)
             return None
 
@@ -185,12 +212,33 @@ def logout_of_divbase(token_path: Path = cli_settings.TOKENS_PATH) -> None:
                 category=UserWarning,
             )
 
-    token_path.unlink(missing_ok=True)
+    _delete_stored_jwts(token_path)
     config.set_login_status(url=None, email=None)
 
 
 def load_user_tokens(token_path: Path = cli_settings.TOKENS_PATH) -> TokenData | None:
-    """Load user tokens from the specified path, return None if no tokens file found"""
+    """
+    Load user tokens from the OS keyring. Fallback for this is a local file with 0600 permissions.
+    Return None if no tokens found or if tokens are malformed/invalid - user logged out.
+    """
+    try:
+        raw = keyring.get_password(service_name=cli_settings.KEYRING_SERVICE, username=cli_settings.KEYRING_USERNAME)
+    except KeyringError as e:
+        raw = None
+        logger.debug(f"Keyring read failed with error: {e}, falling back to file storage.")
+
+    if raw is not None:
+        try:
+            token_dict = json.loads(raw)
+            return TokenData(
+                access_token=SecretStr(token_dict["access_token"]),
+                refresh_token=SecretStr(token_dict["refresh_token"]),
+                access_token_expires_at=token_dict["access_token_expires_at"],
+                refresh_token_expires_at=token_dict["refresh_token_expires_at"],
+            )
+        except (KeyError, json.JSONDecodeError) as e:
+            logger.debug(f"Keyring token data malformed: {e}")
+
     if not token_path.exists():
         return None
 
@@ -207,6 +255,7 @@ def load_user_tokens(token_path: Path = cli_settings.TOKENS_PATH) -> TokenData |
     except KeyError as e:
         logger.debug(f"User tokens file at {token_path} appears to be malformed: {e}")
         return None
+
     return token_data
 
 
@@ -227,7 +276,7 @@ def make_authenticated_request(
         if not cli_settings.DIVBASE_API_PAT:
             raise AuthenticationError(LOGIN_AGAIN_MESSAGE)
         logger.info("Using personal access token in request to DivBase API.")
-        headers["Authorization"] = f"Bearer {cli_settings.DIVBASE_API_PAT}"
+        headers["Authorization"] = f"Bearer {cli_settings.DIVBASE_API_PAT.get_secret_value()}"
     else:
         if token_data.is_access_token_expired():
             if token_data.is_refresh_token_expired():

--- a/packages/divbase-cli/src/divbase_cli/user_auth.py
+++ b/packages/divbase-cli/src/divbase_cli/user_auth.py
@@ -68,7 +68,8 @@ class TokenData:
 
         output_path.parent.mkdir(parents=True, exist_ok=True)
         # Create file with 0600 permissions (user read/write only).
-        # Windows doesn't support 0600 permissions, but Windows can use keyring.
+        # Windows doesn't support 0600 permissions, but Windows can use keyring, so should never reach this fallback.
+        # Even if a Windows OS can't use keyring the fallback will still work, the 0600 mode will just be ignored.
         fd = os.open(path=output_path, flags=os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode=0o600)
         with os.fdopen(fd, "w") as file:
             yaml.safe_dump(token_dict, file, sort_keys=False)

--- a/packages/divbase-cli/src/divbase_cli/user_auth.py
+++ b/packages/divbase-cli/src/divbase_cli/user_auth.py
@@ -283,6 +283,7 @@ def make_authenticated_request(
                 # Prevents user getting warning about being already logged in when they try to log in again
                 config = load_user_config()
                 config.set_login_status(url=None, email=None)
+                _delete_stored_jwts(token_path)
                 raise AuthenticationError(LOGIN_AGAIN_MESSAGE)
             else:
                 token_data = _refresh_access_token(token_data=token_data, divbase_base_url=divbase_base_url)

--- a/packages/divbase-cli/src/divbase_cli/user_auth.py
+++ b/packages/divbase-cli/src/divbase_cli/user_auth.py
@@ -3,8 +3,8 @@ Manage user authentication with the DivBase server.
 
 This includes login/logout and the getting, storing, using, and refreshing of access + refresh JWTs and Personal Access Tokens (PATs).
 
-User JWTs are stored in the devices's OS keyring. They fallback to a local file with 0600 permissions if not possible.
-PATS provided via enviroment variable
+User JWTs are stored in the device's OS keyring. They fallback to a local file with 0600 permissions if not possible.
+PATs provided via environment variable
 """
 
 import contextlib
@@ -362,6 +362,7 @@ def _refresh_access_token(token_data: TokenData, divbase_base_url: str) -> Token
             # Prevents user getting warning about being already logged in when they try to log in again.
             config = load_user_config()
             config.set_login_status(url=None, email=None)
+            _delete_stored_jwts(token_path=cli_settings.TOKENS_PATH)
             raise AuthenticationError(LOGIN_AGAIN_MESSAGE) from None
 
         _handle_divbase_api_error(response=response, http_method="POST", url=refresh_url)

--- a/packages/divbase-lib/src/divbase_lib/divbase_constants.py
+++ b/packages/divbase-lib/src/divbase_lib/divbase_constants.py
@@ -51,3 +51,6 @@ QUERY_RESULTS_FILE_PREFIX = "result_of_job_"
 # 2. Add an announcement about a new CLI version being available when the user logs in.
 # 3. Do Nothing as the user's CLI version is up to date.
 CLI_VERSION_HEADER_KEY = "X-CLI-Version"
+
+# Personal Access Tokens (PATs) are used for passwordless auth with DivBase API
+PAT_TOKEN_PREFIX = "divbase_pat_"

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,6 +11,7 @@ env =
     # divbase-cli test settings
     DIVBASE_CLI_CONFIG_PATH=tests/fixtures/tmp/config.yaml
     DIVBASE_CLI_TOKENS_PATH=tests/fixtures/tmp/.fakesecrets
+    DIVBASE_KEYRING_SERVICE=divbase-cli-test
     DIVBASE_API_URL=http://localhost:8001/api
     # API and worker test settings (used in unit tests - as integration/e2e get the settings from docker-compose)
     DIVBASE_ENV=test

--- a/tests/e2e_integration/cli_commands/conftest.py
+++ b/tests/e2e_integration/cli_commands/conftest.py
@@ -7,11 +7,14 @@ The S3FileManager class is patched in all tests to use this test MinIO server,
 it is autoused, so it does not need to be specified in each test.
 """
 
+import contextlib
 import logging
 from pathlib import Path
 
 import boto3
+import keyring
 import pytest
+from keyring.errors import NoKeyringError, PasswordDeleteError
 from typer.testing import CliRunner
 
 from divbase_cli.cli_config import cli_settings
@@ -39,20 +42,6 @@ def tmp_config_path(tmp_path):
     Fixture to provide a path to where the a configuration can be created.
     """
     return tmp_path / "test_config.yaml"
-
-
-@pytest.fixture
-def logged_out_user_with_no_config():
-    """
-    Fixture to provide a user with a fresh config file that is not logged in anywhere.
-    """
-    # ensure no config or tokens file exist before test
-    cli_settings.CONFIG_PATH.unlink(missing_ok=True)
-    cli_settings.TOKENS_PATH.unlink(missing_ok=True)
-    yield
-    # clean up after test, delete config and tokens file
-    cli_settings.CONFIG_PATH.unlink(missing_ok=True)
-    cli_settings.TOKENS_PATH.unlink(missing_ok=True)
 
 
 @pytest.fixture
@@ -130,6 +119,9 @@ def _create_logged_in_user_fixture(user_type: str):
     def factory(CONSTANTS):
         # ensure no config or tokens file exist before test
         cli_settings.CONFIG_PATH.unlink(missing_ok=True)
+        # tokens can either be stored in device keyring (or in a fallback file if e.g. keyring not available - likely for CI or disabled for a test)
+        with contextlib.suppress(NoKeyringError, PasswordDeleteError):
+            keyring.delete_password(service_name=cli_settings.KEYRING_SERVICE, username=cli_settings.KEYRING_USERNAME)
         cli_settings.TOKENS_PATH.unlink(missing_ok=True)
 
         # running any cmd that requires the config file will create it
@@ -156,6 +148,9 @@ def _create_logged_in_user_fixture(user_type: str):
 
         # clean up after test, delete config and tokens file
         cli_settings.CONFIG_PATH.unlink(missing_ok=True)
+        # tokens can either be stored in device keyring (or in a fallback file if e.g. keyring not available - likely for CI or disabled for a test)
+        with contextlib.suppress(NoKeyringError, PasswordDeleteError):
+            keyring.delete_password(service_name=cli_settings.KEYRING_SERVICE, username=cli_settings.KEYRING_USERNAME)
         cli_settings.TOKENS_PATH.unlink(missing_ok=True)
 
     return factory

--- a/tests/e2e_integration/cli_commands/conftest.py
+++ b/tests/e2e_integration/cli_commands/conftest.py
@@ -49,11 +49,9 @@ def logged_out_user_with_existing_config(CONSTANTS):
     """
     Fixture to provide a NOT logged in user with an "existing" user configuration file with
     some existing projects and a default project set.
-    """
-    # ensure no config or tokens file exist before test
-    cli_settings.CONFIG_PATH.unlink(missing_ok=True)
-    cli_settings.TOKENS_PATH.unlink(missing_ok=True)
 
+    NOTE: config and tokens cleaned up before and after tests by clean_tmp_config_and_tokens_between_tests fixture
+    """
     # running any cmd that requires the config file will create it
     # so we can just run the config add cmd directly.
     for project in CONSTANTS["PROJECT_TO_BUCKET_MAP"]:
@@ -66,10 +64,6 @@ def logged_out_user_with_existing_config(CONSTANTS):
     assert result.exit_code == 0
 
     yield
-
-    # clean up after test, delete config and tokens file
-    cli_settings.CONFIG_PATH.unlink(missing_ok=True)
-    cli_settings.TOKENS_PATH.unlink(missing_ok=True)
 
 
 @pytest.fixture
@@ -114,6 +108,9 @@ def _create_logged_in_user_fixture(user_type: str):
 
     Args:
         user_type: One of "admin", "read user", "edit user", "manage user"
+
+    NOTE: Whilst config and tokens cleaned up before and after tests by clean_tmp_config_and_tokens_between_tests fixture
+    This factory can be used multiple times in a single test, hence need to clean up existing config and tokens here too.
     """
 
     def factory(CONSTANTS):

--- a/tests/e2e_integration/cli_commands/test_auth_cli.py
+++ b/tests/e2e_integration/cli_commands/test_auth_cli.py
@@ -27,7 +27,7 @@ def disable_keyring_backend(monkeypatch):
     Awkward to do that if stored in device keyring. So we can disable keyring for these tests,
     which will fall back to storing the JWTs in a file.
 
-    NOTE: In e.g. CI where a keyring backed wont be available, tests will (aka should) still work as they will from the start use the file-based fallback.
+    In e.g. CI where a keyring backend won't be available, tests will still work as they will from the start use the file-based fallback.
     """
     monkeypatch.setattr(keyring, "set_password", lambda *a, **kw: (_ for _ in ()).throw(NoKeyringError()))
     monkeypatch.setattr(keyring, "get_password", lambda *a, **kw: None)

--- a/tests/e2e_integration/cli_commands/test_auth_cli.py
+++ b/tests/e2e_integration/cli_commands/test_auth_cli.py
@@ -4,6 +4,9 @@ E2E tests for the "divbase-cli auth" CLI commands.
 
 import shutil
 
+import keyring
+import pytest
+from keyring.errors import NoKeyringError
 from typer.testing import CliRunner
 
 from divbase_cli.cli_config import cli_settings
@@ -17,16 +20,17 @@ USER_EMAIL = "edit@divbase.se"
 USER_PASSWORD = "badpassword"
 
 
-def log_in_as_user():
+@pytest.fixture()
+def disable_keyring_backend(monkeypatch):
     """
-    Helper function to log in as a user.
-    Not a fixture as want to ensure logged out before and after each test and could be timing issues when
-    combined with other fixtures (e.g. ensure_logged_out).
+    Some tests want to manipulate the JWTs (to e.g. simulate making them being expired or revoked).
+    Awkward to do that if stored in device keyring. So we can disable keyring for these tests,
+    which will fall back to storing the JWTs in a file.
+
+    NOTE: In e.g. CI where a keyring backed wont be available, tests will (aka should) still work as they will from the start use the file-based fallback.
     """
-    command = f"auth login {USER_EMAIL}"
-    result = runner.invoke(app=app, args=command, input=f"{USER_PASSWORD}\n")
-    assert result.exit_code == 0
-    assert "Logged in successfully" in result.stdout
+    monkeypatch.setattr(keyring, "set_password", lambda *a, **kw: (_ for _ in ()).throw(NoKeyringError()))
+    monkeypatch.setattr(keyring, "get_password", lambda *a, **kw: None)
 
 
 def make_tokens_expired(access: bool = False, refresh: bool = False):
@@ -46,16 +50,12 @@ def make_tokens_expired(access: bool = False, refresh: bool = False):
                 token_file.write(line)
 
 
-def test_login_command(logged_out_user_with_no_config):
-    command = f"auth login {USER_EMAIL}"
-
-    result = runner.invoke(app=app, args=command, input=f"{USER_PASSWORD}\n")
-    assert result.exit_code == 0
-    assert "Logged in successfully" in result.stdout
-    assert USER_EMAIL in result.stdout
-
-
-def test_login_command_with_password_prompted(logged_out_user_with_no_config):
+def log_in_as_user():
+    """
+    Helper function to log in as a user.
+    Not a fixture as want to ensure logged out before and after each test and could be timing issues when
+    combined with other fixtures (e.g. ensure_logged_out).
+    """
     command = f"auth login {USER_EMAIL}"
     result = runner.invoke(app=app, args=command, input=f"{USER_PASSWORD}\n")
     assert result.exit_code == 0
@@ -63,7 +63,11 @@ def test_login_command_with_password_prompted(logged_out_user_with_no_config):
     assert USER_EMAIL in result.stdout
 
 
-def test_login_command_fails_with_invalid_credentials(logged_out_user_with_no_config):
+def test_login_command():
+    log_in_as_user()
+
+
+def test_login_command_fails_with_invalid_credentials():
     """Test login command fails with invalid credentials."""
     command = f"auth login {USER_EMAIL}"
 
@@ -73,7 +77,7 @@ def test_login_command_fails_with_invalid_credentials(logged_out_user_with_no_co
     assert "Invalid email or password" in str(result.exception)
 
 
-def test_login_command_with_invalid_server_url(logged_out_user_with_no_config):
+def test_login_command_with_invalid_server_url():
     """Test login command fails with an invalid server URL."""
     command = f"auth login {USER_EMAIL} --divbase-url https://invalid-url"
 
@@ -82,7 +86,7 @@ def test_login_command_with_invalid_server_url(logged_out_user_with_no_config):
     assert isinstance(result.exception, DivBaseAPIConnectionError)
 
 
-def test_login_command_already_logged_in(logged_out_user_with_no_config):
+def test_login_command_already_logged_in():
     """Test login command when already logged in."""
     log_in_as_user()
 
@@ -104,7 +108,7 @@ def test_login_command_already_logged_in(logged_out_user_with_no_config):
     assert USER_EMAIL in result.stdout
 
 
-def test_force_login_option(logged_out_user_with_no_config):
+def test_force_login_option():
     """Should not prompt about logging in again"""
     log_in_as_user()
     command = f"auth login {USER_EMAIL} --force"
@@ -115,7 +119,7 @@ def test_force_login_option(logged_out_user_with_no_config):
     assert USER_EMAIL in result.stdout
 
 
-def test_logout_command(logged_out_user_with_no_config):
+def test_logout_command():
     """Test basic usage of logout and that running multiple times is ok."""
     command = "auth logout"
 
@@ -128,7 +132,7 @@ def test_logout_command(logged_out_user_with_no_config):
     assert "Logged out successfully" in result.stdout
 
 
-def test_login_logout_cycle(logged_out_user_with_no_config):
+def test_login_logout_cycle():
     """Test a few repeated login/logout cycles."""
     login_command = f"auth login {USER_EMAIL} --force"
     logout_command = "auth logout"
@@ -144,7 +148,7 @@ def test_login_logout_cycle(logged_out_user_with_no_config):
         assert "Logged out successfully" in result.stdout
 
 
-def test_whoami_command(logged_out_user_with_no_config):
+def test_whoami_command():
     """Test basic usage of whoami command."""
     log_in_as_user()
     command = "auth whoami"
@@ -154,7 +158,7 @@ def test_whoami_command(logged_out_user_with_no_config):
     assert USER_EMAIL in result.stdout
 
 
-def test_whoami_command_fails_if_not_logged_in(logged_out_user_with_no_config):
+def test_whoami_command_fails_if_not_logged_in():
     """Test basic usage of whoami command."""
     command = "auth whoami"
 
@@ -163,7 +167,7 @@ def test_whoami_command_fails_if_not_logged_in(logged_out_user_with_no_config):
     assert isinstance(result.exception, AuthenticationError)
 
 
-def test_whoami_command_needing_refresh_token(logged_out_user_with_no_config):
+def test_whoami_command_needing_refresh_token(disable_keyring_backend):
     """
     We simulate that the access token has expired by manually setting it to be expired in the users .secrets file
 
@@ -178,24 +182,24 @@ def test_whoami_command_needing_refresh_token(logged_out_user_with_no_config):
     assert USER_EMAIL in result.stdout
 
 
-def test_whoami_with_expired_tokens_fails(logged_in_admin_with_existing_config):
+def test_whoami_with_expired_tokens_fails(disable_keyring_backend):
     """
     Simulate that both the access token and refresh token have expired by manually setting them to be expired
     in the users .secrets file.
 
     This should force authentication to fail when running the whoami command, requiring the user to log in again.
     """
-    command = "auth whoami"
-
+    log_in_as_user()
     make_tokens_expired(access=True, refresh=True)
 
+    command = "auth whoami"
     result = runner.invoke(app=app, args=command)
     assert result.exit_code != 0
     assert isinstance(result.exception, AuthenticationError)
     assert LOGIN_AGAIN_MESSAGE in str(result.exception)
 
 
-def test_using_revoked_refresh_token_fails(logged_out_user_with_no_config, tmp_path):
+def test_using_revoked_refresh_token_fails(tmp_path, disable_keyring_backend):
     """
     Validate that when the refresh token is revoked, the user cannot use it to get a new access token.
 
@@ -236,7 +240,7 @@ def test_using_revoked_refresh_token_fails(logged_out_user_with_no_config, tmp_p
     assert USER_EMAIL in result.stdout
 
 
-def test_login_with_outdated_cli_version_fails(logged_out_user_with_no_config, monkeypatch):
+def test_login_with_outdated_cli_version_fails(monkeypatch):
     """Test that login fails if the CLI version is outdated (rejected by the API middleware)"""
     monkeypatch.setattr("divbase_cli.user_auth.cli_version", "0.0.0")
 
@@ -249,7 +253,7 @@ def test_login_with_outdated_cli_version_fails(logged_out_user_with_no_config, m
     assert "cli_version_outdated_error" in str(result.exception)
 
 
-def test_any_command_with_outdated_cli_version_fails(logged_out_user_with_no_config, monkeypatch):
+def test_any_command_with_outdated_cli_version_fails(monkeypatch):
     """Test that any command fails if the CLI version is outdated."""
     log_in_as_user()
 

--- a/tests/e2e_integration/cli_commands/test_auth_cli.py
+++ b/tests/e2e_integration/cli_commands/test_auth_cli.py
@@ -7,6 +7,7 @@ import shutil
 import keyring
 import pytest
 from keyring.errors import NoKeyringError
+from pydantic import SecretStr
 from typer.testing import CliRunner
 
 from divbase_cli.cli_config import cli_settings
@@ -266,3 +267,18 @@ def test_any_command_with_outdated_cli_version_fails(monkeypatch):
     assert isinstance(result.exception, DivBaseAPIError)
     assert "400" in str(result.exception)
     assert "cli_version_outdated_error" in str(result.exception)
+
+
+def test_jwt_session_takes_priority_over_pat(disable_keyring_backend, monkeypatch):
+    """
+    When a JWT session (stored in fallback file) and a PAT are both available, the JWT is used.
+
+    We know it works as if the PAT was used, would get error as PAT made up.
+    """
+    log_in_as_user()
+
+    monkeypatch.setattr(cli_settings, "DIVBASE_API_PAT", SecretStr("divbase_pat_fake_not_a_real_token"))
+
+    result = runner.invoke(app=app, args="auth whoami")
+    assert result.exit_code == 0
+    assert USER_EMAIL in result.stdout

--- a/tests/e2e_integration/cli_commands/test_personal_access_tokens.py
+++ b/tests/e2e_integration/cli_commands/test_personal_access_tokens.py
@@ -15,6 +15,7 @@ from datetime import datetime, timedelta, timezone
 
 import httpx
 import pytest
+from pydantic import SecretStr
 from sqlalchemy import delete, select
 from typer.testing import CliRunner
 
@@ -71,7 +72,7 @@ def pat_factory(db_session_sync):
     """Creates a single PAT directly in the DB and deletes it after the test."""
     pat_id: int | None = None
 
-    def create_pat(user_email, permissions=FULL_ACCESS_PAT_PERMISSIONS, expires_at=None):
+    def create_pat(user_email, permissions=FULL_ACCESS_PAT_PERMISSIONS, expires_at=None) -> SecretStr:
         nonlocal pat_id
         user = db_session_sync.execute(select(UserDB).where(UserDB.email == user_email)).scalar_one()
         raw = generate_personal_access_token()
@@ -86,7 +87,7 @@ def pat_factory(db_session_sync):
         db_session_sync.commit()
         db_session_sync.refresh(pat)
         pat_id = pat.id
-        return raw.get_secret_value()
+        return raw
 
     yield create_pat
 

--- a/tests/e2e_integration/cli_commands/test_personal_access_tokens.py
+++ b/tests/e2e_integration/cli_commands/test_personal_access_tokens.py
@@ -272,9 +272,9 @@ def test_pat_does_not_work_on_frontend_endpoints(
 
     home_url = "http://localhost:8001/"
     # technically don't need the token here
-    response = httpx.get(home_url, headers={"Authorization": f"Bearer {raw_token}"})
+    response = httpx.get(home_url, headers={"Authorization": f"Bearer {raw_token.get_secret_value()}"})
     assert response.status_code == 200
 
     profile_url = "http://localhost:8001/profile/"
-    response = httpx.get(profile_url, headers={"Authorization": f"Bearer {raw_token}"})
+    response = httpx.get(profile_url, headers={"Authorization": f"Bearer {raw_token.get_secret_value()}"})
     assert response.status_code == 302  # redirected to login, so rejected as expected

--- a/tests/e2e_integration/cli_commands/test_user_config_cli.py
+++ b/tests/e2e_integration/cli_commands/test_user_config_cli.py
@@ -2,7 +2,7 @@
 Tests for the user configuration CLI commands.
 
 Tests start from 1 of 2 types of user config files:
-- logged_out_user_with_no_config: A brand new user who has not run a single divbase-cli command before.
+- : A brand new user who has not run a single divbase-cli command before.
 - logged_out_user_with_existing_config: A config file with some pre-existing projects and a default project set.
 """
 
@@ -15,7 +15,7 @@ from divbase_cli.user_config import load_user_config
 runner = CliRunner()
 
 
-def test_add_project_command(logged_out_user_with_no_config):
+def test_add_project_command():
     project_name = "test_project"
     command = f"config add {project_name}"
     result = runner.invoke(app, command)
@@ -25,7 +25,7 @@ def test_add_project_command(logged_out_user_with_no_config):
     assert project_name in config_contents.all_project_names
 
 
-def test_add_project_as_default_command(logged_out_user_with_no_config):
+def test_add_project_as_default_command():
     project_name = "test_project"
 
     command = f"config add {project_name} --default"
@@ -37,7 +37,7 @@ def test_add_project_as_default_command(logged_out_user_with_no_config):
     assert config.default_project == project_name
 
 
-def test_add_project_and_specify_urls(logged_out_user_with_no_config):
+def test_add_project_and_specify_urls():
     project_name = "test_project"
     divbase_url = "https://divbasewebsite.com"
 
@@ -53,7 +53,7 @@ def test_add_project_and_specify_urls(logged_out_user_with_no_config):
     assert project.divbase_url == divbase_url
 
 
-def test_add_project_that_already_exists(logged_out_user_with_no_config):
+def test_add_project_that_already_exists():
     """
     Should warn user and not be duplicated in the config.
     The newer project settings should be in the config file (i.e. overwrite the old ones).
@@ -109,7 +109,7 @@ def test_show_default_project_command(logged_out_user_with_existing_config, CONS
     assert CONSTANTS["DEFAULT_PROJECT"] in result.output
 
 
-def test_show_default_with_no_default_set_command(logged_out_user_with_no_config):
+def test_show_default_with_no_default_set_command():
     command = "config show-default"
     result = runner.invoke(app, command)
     assert result.exit_code == 0
@@ -166,7 +166,7 @@ def test_show_user_config_command(logged_out_user_with_existing_config, CONSTANT
         assert project_name in result.output
 
 
-def test_show_user_config_with_no_projects_command(logged_out_user_with_no_config):
+def test_show_user_config_with_no_projects_command():
     command = "config show"
     result = runner.invoke(app, command)
 

--- a/tests/e2e_integration/cli_commands/test_user_config_cli.py
+++ b/tests/e2e_integration/cli_commands/test_user_config_cli.py
@@ -2,7 +2,7 @@
 Tests for the user configuration CLI commands.
 
 Tests start from 1 of 2 types of user config files:
-- : A brand new user who has not run a single divbase-cli command before.
+- A brand new user who has not run a single divbase-cli command before. (no fixture needed, config and tokens auto cleaned between tests)
 - logged_out_user_with_existing_config: A config file with some pre-existing projects and a default project set.
 """
 

--- a/tests/e2e_integration/conftest.py
+++ b/tests/e2e_integration/conftest.py
@@ -5,9 +5,12 @@ It handles spinning up the job system docker stack for the duration of the test 
 It also collects fixtures and constants that are needed across multiple test modules.
 """
 
+import contextlib
 import logging
 
+import keyring
 import pytest
+from keyring.errors import NoKeyringError, PasswordDeleteError
 from typer.testing import CliRunner
 
 from divbase_api.worker.crud_dimensions import (
@@ -37,18 +40,23 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(autouse=True, scope="function")
-def clean_tmp_config_token_dir():
+def clean_tmp_config_and_tokens_between_tests():
     """
-    To avoid test pollution, ensure that any config or token files created in tests
-    are removed after each test function and are not created where the local dev/user has their config or token file.
-
-    Related to this fixture is cli_config.py where the cli_settings instance is created at module load time.
-    Using env variables we point to these "testing" paths instead for the config and token paths.
+    To avoid test pollution, ensure that any config or token files created in a test from logging in
+    is removed before each test is run.
     """
     cli_settings.CONFIG_PATH.unlink(missing_ok=True)
+    # tokens can either be stored in device keyring (or in a fallback file if e.g. keyring not available - likely for CI or disabled for a test)
+    with contextlib.suppress(NoKeyringError, PasswordDeleteError):
+        keyring.delete_password(service_name=cli_settings.KEYRING_SERVICE, username=cli_settings.KEYRING_USERNAME)
     cli_settings.TOKENS_PATH.unlink(missing_ok=True)
+
     yield
+
     cli_settings.CONFIG_PATH.unlink(missing_ok=True)
+    # tokens can either be stored in device keyring (or in a fallback file if e.g. keyring not available - likely for CI or disabled for a test)
+    with contextlib.suppress(NoKeyringError, PasswordDeleteError):
+        keyring.delete_password(service_name=cli_settings.KEYRING_SERVICE, username=cli_settings.KEYRING_USERNAME)
     cli_settings.TOKENS_PATH.unlink(missing_ok=True)
 
 

--- a/tests/e2e_integration/playwright/test_personal_access_tokens.py
+++ b/tests/e2e_integration/playwright/test_personal_access_tokens.py
@@ -14,6 +14,7 @@ from divbase_api.crud.personal_access_tokens import PAT_MAX_ACTIVE_TOKENS
 from divbase_api.models.personal_access_tokens import PersonalAccessTokenDB
 from divbase_api.models.users import UserDB
 from divbase_api.security import generate_personal_access_token, hash_personal_access_token
+from divbase_lib.divbase_constants import PAT_TOKEN_PREFIX
 
 from .conftest import FRONTEND_BASE_URL, _create_logged_in_user_page, navigate_to
 
@@ -92,9 +93,9 @@ def test_create_full_access_pat_shows_token(logged_in_edit_user_pat_page: Page):
     expect(logged_in_edit_user_pat_page.get_by_role("heading", name="Token generated")).to_be_visible()
     expect(logged_in_edit_user_pat_page.get_by_text("Copy your token now, it will not be shown again.")).to_be_visible()
     # The raw token element contains the token value; verify its prefix
-    token_text = logged_in_edit_user_pat_page.get_by_text(re.compile(r"divbase_pat_")).first.text_content()
+    token_text = logged_in_edit_user_pat_page.get_by_text(re.compile(rf"{PAT_TOKEN_PREFIX}")).first.text_content()
     assert token_text is not None
-    assert token_text.strip().startswith("divbase_pat_")
+    assert token_text.strip().startswith(PAT_TOKEN_PREFIX)
 
 
 def test_created_pat_appears_in_list(logged_in_edit_user_pat_page: Page):

--- a/tests/unit/divbase_cli/test_user_auth.py
+++ b/tests/unit/divbase_cli/test_user_auth.py
@@ -1,17 +1,37 @@
+import contextlib
+import json
+import stat
 import time
 from unittest.mock import MagicMock, patch
 
+import keyring
 import pytest
+from keyring.errors import KeyringError, NoKeyringError, PasswordDeleteError
 from pydantic import SecretStr
 
+from divbase_cli.cli_config import cli_settings
 from divbase_cli.user_auth import (
     TokenData,
+    _delete_stored_jwts,
     check_existing_session,
+    load_user_tokens,
 )
+
+# cli config set to use "divbase-cli-test" (via pytest.ini) as the keyring service name,
+# so tokens and PATs stored in tests don't interfere with real credentials in dev computer with service name "divbase-cli"
+_TEST_KEYRING_SERVICE = "divbase-cli-test"
+
+
+@pytest.fixture(autouse=True)
+def clean_up_keyring_entries():
+    """Clean up any test keyring entries added after each test"""
+    yield
+    with contextlib.suppress(NoKeyringError, PasswordDeleteError):
+        keyring.delete_password(service_name=_TEST_KEYRING_SERVICE, username=cli_settings.KEYRING_USERNAME)
 
 
 @pytest.fixture
-def mock_logged_out_config():
+def mock_logged_out_user_config():
     """Fixture to provide a mock user config"""
     config = MagicMock()
     config.logged_in_url = None
@@ -21,8 +41,7 @@ def mock_logged_out_config():
 
 
 @pytest.fixture
-def mock_logged_in_config():
-    """Fixture to provide a mock user config"""
+def mock_logged_in_user_config():
     config = MagicMock()
     config.logged_in_url = "https://divbase.com"
     config.logged_in_email = "test@divbase.com"
@@ -32,7 +51,6 @@ def mock_logged_in_config():
 
 @pytest.fixture
 def mock_token_data():
-    """Fixture to provide a mock token data"""
     return TokenData(
         access_token=SecretStr("access"),
         refresh_token=SecretStr("refresh"),
@@ -57,26 +75,102 @@ def test_is_refresh_token_expired_method(mock_token_data):
     assert mock_token_data.is_refresh_token_expired() is True
 
 
-def test_check_existing_session_not_logged_in(mock_logged_out_config):
+def test_check_existing_session_not_logged_in(mock_logged_out_user_config):
     """Test that check_existing_session returns None if not logged in."""
 
-    result = check_existing_session("https://divbase.com", mock_logged_out_config)
+    result = check_existing_session("https://divbase.com", mock_logged_out_user_config)
     assert result is None
 
 
 @patch("divbase_cli.user_auth.load_user_tokens")
-def test_check_existing_session_when_logged_in_to_different_divbase_url(mock_logged_in_config):
+def test_check_existing_session_when_logged_in_to_different_divbase_url(mock_logged_in_user_config):
     """Test that check_existing_session returns None if logged in to a different divbase URL."""
 
-    result = check_existing_session("https://otherdivbaseinstance.com", mock_logged_in_config)
+    result = check_existing_session("https://otherdivbaseinstance.com", mock_logged_in_user_config)
     assert result is None
 
 
 @patch("divbase_cli.user_auth.load_user_tokens")
-def test_check_existing_session_when_logged_in(mock_load_user_tokens, mock_logged_in_config, mock_token_data):
+def test_check_existing_session_when_logged_in(mock_load_user_tokens, mock_logged_in_user_config, mock_token_data):
     """Test that check_existing_session returns refresh token expiry if logged in."""
     mock_load_user_tokens.return_value = mock_token_data
 
-    result = check_existing_session("https://divbase.com", mock_logged_in_config)
+    result = check_existing_session("https://divbase.com", mock_logged_in_user_config)
     assert result == mock_token_data.refresh_token_expires_at
     mock_load_user_tokens.assert_called_once()
+
+
+@patch("divbase_cli.user_auth.keyring.set_password", side_effect=NoKeyringError)
+def test_dump_tokens_falls_back_to_file_when_no_keyring(mock_set_password, mock_token_data, tmp_path):
+    """
+    If afftempt to dump tokens with keyring fails, tokens should be written to a file with 0600 permissions."""
+    output = tmp_path / ".secrets"
+
+    mock_token_data.dump_tokens(output_path=output)
+
+    assert output.exists()
+    file_mode = stat.S_IMODE(output.stat().st_mode)
+    assert file_mode == 0o600
+
+
+@patch("divbase_cli.user_auth.keyring.set_password", side_effect=KeyringError("backend error"))
+def test_dump_tokens_falls_back_to_file_on_keyring_error(mock_set_password, mock_token_data, tmp_path):
+    """dump_tokens writes a 0600 file when an unexpected keyring error occurs."""
+    output = tmp_path / ".secrets"
+
+    mock_token_data.dump_tokens(output_path=output)
+
+    assert output.exists()
+    file_mode = stat.S_IMODE(output.stat().st_mode)
+    assert file_mode == 0o600
+
+
+@patch("divbase_cli.user_auth.keyring.get_password")
+def test_load_user_tokens_reads_from_keyring(mock_get_password, mock_token_data, tmp_path):
+    """load_user_tokens returns tokens from keyring when present."""
+    mock_get_password.return_value = json.dumps(
+        {
+            "access_token": "access",
+            "refresh_token": "refresh",
+            "access_token_expires_at": mock_token_data.access_token_expires_at,
+            "refresh_token_expires_at": mock_token_data.refresh_token_expires_at,
+        }
+    )
+
+    result = load_user_tokens(token_path=tmp_path / ".secrets")
+
+    assert result is not None
+    assert result.access_token.get_secret_value() == "access"
+    assert result.refresh_token.get_secret_value() == "refresh"
+
+
+@patch("divbase_cli.user_auth.keyring.get_password", side_effect=NoKeyringError)
+def test_load_user_tokens_falls_back_to_file_when_no_keyring(mock_get_password, mock_token_data, tmp_path):
+    """load_user_tokens reads from file when keyring is unavailable."""
+    token_file = tmp_path / ".secrets"
+    token_file.write_text(
+        f"access_token: access\n"
+        f"refresh_token: refresh\n"
+        f"access_token_expires_at: {mock_token_data.access_token_expires_at}\n"
+        f"refresh_token_expires_at: {mock_token_data.refresh_token_expires_at}\n"
+    )
+
+    result = load_user_tokens(token_path=token_file)
+
+    assert result is not None
+    assert result.access_token.get_secret_value() == "access"
+
+
+@patch("divbase_cli.user_auth.keyring.get_password", return_value=None)
+def test_load_user_tokens_returns_none_when_no_tokens(mock_get_password, tmp_path):
+    """load_user_tokens returns None when neither keyring nor file has tokens."""
+    result = load_user_tokens(token_path=tmp_path / ".secrets")
+    assert result is None
+
+
+@patch("divbase_cli.user_auth.keyring.delete_password", side_effect=PasswordDeleteError)
+def test_delete_stored_tokens_tolerates_missing_keyring_entry(mock_delete_password, tmp_path):
+    """_delete_stored_jwts does not raise if the keyring entry doesn't exist."""
+    token_file = tmp_path / ".secrets"
+    _delete_stored_jwts(token_file)
+    _delete_stored_jwts(token_file)

--- a/tests/unit/divbase_cli/test_user_auth.py
+++ b/tests/unit/divbase_cli/test_user_auth.py
@@ -173,3 +173,30 @@ def test_delete_stored_tokens_tolerates_missing_keyring_entry(mock_delete_passwo
     token_file = tmp_path / ".secrets"
     _delete_stored_jwts(token_file)
     _delete_stored_jwts(token_file)
+
+
+@patch("divbase_cli.user_auth.keyring.get_password")
+def test_load_user_tokens_keyring_takes_priority_over_file(mock_get_password, mock_token_data, tmp_path):
+    """
+    Assert that when tokens exist in both keyring and the fallback file,
+    keyring tokens take priority. -  we mock a keyring creation.
+    """
+    mock_get_password.return_value = json.dumps(
+        {
+            "access_token": "keyring_access",
+            "refresh_token": "keyring_refresh",
+            "access_token_expires_at": mock_token_data.access_token_expires_at,
+            "refresh_token_expires_at": mock_token_data.refresh_token_expires_at,
+        }
+    )
+    token_file = tmp_path / ".secrets"
+    token_file.write_text(
+        "access_token: file_access\n"
+        "refresh_token: file_refresh\n"
+        f"access_token_expires_at: {mock_token_data.access_token_expires_at}\n"
+        f"refresh_token_expires_at: {mock_token_data.refresh_token_expires_at}\n"
+    )
+
+    result = load_user_tokens(token_path=token_file)
+    assert result is not None
+    assert result.access_token.get_secret_value() == "keyring_access"

--- a/tests/unit/divbase_cli/test_user_auth.py
+++ b/tests/unit/divbase_cli/test_user_auth.py
@@ -82,7 +82,6 @@ def test_check_existing_session_not_logged_in(mock_logged_out_user_config):
     assert result is None
 
 
-@patch("divbase_cli.user_auth.load_user_tokens")
 def test_check_existing_session_when_logged_in_to_different_divbase_url(mock_logged_in_user_config):
     """Test that check_existing_session returns None if logged in to a different divbase URL."""
 
@@ -103,7 +102,7 @@ def test_check_existing_session_when_logged_in(mock_load_user_tokens, mock_logge
 @patch("divbase_cli.user_auth.keyring.set_password", side_effect=NoKeyringError)
 def test_dump_tokens_falls_back_to_file_when_no_keyring(mock_set_password, mock_token_data, tmp_path):
     """
-    If afftempt to dump tokens with keyring fails, tokens should be written to a file with 0600 permissions."""
+    If attempt to dump tokens with keyring fails, tokens should be written to a file with 0600 permissions."""
     output = tmp_path / ".secrets"
 
     mock_token_data.dump_tokens(output_path=output)

--- a/tests/unit/divbase_cli/test_user_config.py
+++ b/tests/unit/divbase_cli/test_user_config.py
@@ -8,7 +8,7 @@ from divbase_cli.user_config import ProjectNotInConfigError, create_user_config,
 
 @pytest.fixture(autouse=True)
 def clean_up_user_config() -> Generator[None, None, None]:
-    """Ensure the user config and tokens file do not exist before each test and are removed after each test."""
+    """Clean up user config before + after each test to ensure no test pollution."""
     cli_settings.CONFIG_PATH.unlink(missing_ok=True)
     yield
     cli_settings.CONFIG_PATH.unlink(missing_ok=True)

--- a/tests/unit/divbase_cli/test_user_config.py
+++ b/tests/unit/divbase_cli/test_user_config.py
@@ -10,10 +10,8 @@ from divbase_cli.user_config import ProjectNotInConfigError, create_user_config,
 def clean_up_user_config() -> Generator[None, None, None]:
     """Ensure the user config and tokens file do not exist before each test and are removed after each test."""
     cli_settings.CONFIG_PATH.unlink(missing_ok=True)
-    cli_settings.TOKENS_PATH.unlink(missing_ok=True)
     yield
     cli_settings.CONFIG_PATH.unlink(missing_ok=True)
-    cli_settings.TOKENS_PATH.unlink(missing_ok=True)
 
 
 def test_config_auto_made_if_no_config_file() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -596,6 +596,50 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "46.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
+    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
+    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
+    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
+    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
+    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
+    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
+    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
+    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
+    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
+    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
+    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
+]
+
+[[package]]
 name = "cssselect"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -703,12 +747,14 @@ name = "divbase-cli"
 source = { editable = "packages/divbase-cli" }
 dependencies = [
     { name = "divbase-lib" },
+    { name = "keyring" },
     { name = "typer" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "divbase-lib", editable = "packages/divbase-lib" },
+    { name = "keyring", specifier = ">=25.7.0" },
     { name = "typer", specifier = "==0.24.1" },
 ]
 
@@ -1113,6 +1159,48 @@ wheels = [
 ]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb", size = 19943, upload-time = "2025-12-21T09:29:43.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl", hash = "sha256:9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176", size = 10481, upload-time = "2025-12-21T09:29:42.27Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1131,6 +1219,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -2312,6 +2417,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2564,6 +2678,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/86/59/a451d7420a77ab0b98f7affa3a1d78a313d2f7281a57afb1a34bae8ab412/seaborn-0.13.2.tar.gz", hash = "sha256:93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7", size = 1457696, upload-time = "2024-01-25T13:21:52.551Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl", hash = "sha256:636f8336facf092165e27924f223d3c62ca560b1f2bb5dff7ab7fad265361987", size = 294914, upload-time = "2024-01-25T13:21:49.598Z" },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR covers a nice security enhancement for CLI users. Rather than storing the user access + refresh tokens in a plain text file, we now use (where possible) the OS keychain to store them, using the python library `keyring` to handle getting/setting etc for us. 

It's not guaranteed that every user will have a keychain available so there is a fallback in which a file is saved with 0600 permissions (user only read and write). The most likely scenario for the fallback would likely be running tests with the gh actions runner. - So I also [ran the test suite for this branch with GH actions to be sure it would work here. ](https://github.com/ScilifelabDataCentre/divbase/actions/runs/24878068679/job/72839814427)

Something I will consider in the future is whether we can also store personal access tokens here (as an alternative than passing as an environment variable), but I want to first see how the keychain implementation works in a HPC setting including via submitted jobs. If it does work then I would like to consider an extension to include also being able to store PATs. 