### PR TITLE
SQ-897: Add tsv output option to task-history commands

### DIFF
--- a/packages/divbase-cli/src/divbase_cli/cli_commands/task_history_cli.py
+++ b/packages/divbase-cli/src/divbase_cli/cli_commands/task_history_cli.py
@@ -9,6 +9,7 @@ import logging
 
 import typer
 
+from divbase_cli.cli_commands.shared_args_options import FORMAT_AS_TSV_OPTION
 from divbase_cli.config_resolver import ensure_logged_in, resolve_project, resolve_url_for_non_project_specific_commands
 from divbase_cli.display_task_history import TaskHistoryDisplayManager
 from divbase_cli.user_auth import make_authenticated_request
@@ -26,6 +27,7 @@ task_history_app = typer.Typer(
 
 @task_history_app.command("user")
 def list_task_history_for_user(
+    format_output_as_tsv: bool = FORMAT_AS_TSV_OPTION,
     limit: int = typer.Option(10, help="Maximum number of tasks to display in the terminal. Sorted by recency."),
     project: str | None = typer.Option(
         None, help="Optional project name to filter the user's task history by project."
@@ -59,12 +61,14 @@ def list_task_history_for_user(
         project_name=project,
         mode="user_project" if project else "user",
         display_limit=limit,
+        format_output_as_tsv=format_output_as_tsv,
     ).print_task_history()
 
 
 @task_history_app.command("id")
 def task_history_by_id(
     task_id: int | None = typer.Argument(..., help="Task ID to check the status of a specific query job."),
+    format_output_as_tsv: bool = FORMAT_AS_TSV_OPTION,
 ):
     """
     Check status of a specific task submitted by the user by its task ID.
@@ -83,6 +87,7 @@ def task_history_by_id(
         user_email=None,
         project_name=None,
         mode="id",
+        format_output_as_tsv=format_output_as_tsv,
     ).print_task_history()
 
 
@@ -93,6 +98,7 @@ def list_task_history_for_project(
         help="Project name to check the task history for. Leave blank to use the default project set in your config.",
     ),
     limit: int = typer.Option(10, help="Maximum number of tasks to display in the terminal. Sorted by recency."),
+    format_output_as_tsv: bool = FORMAT_AS_TSV_OPTION,
 ):
     """
     Check status of all tasks submitted for a project. Requires a manager role in the project. Displays the latest 10 tasks by default, unless --limit is specified.
@@ -115,4 +121,5 @@ def list_task_history_for_project(
         project_name=project_config.name,
         mode="project",
         display_limit=limit,
+        format_output_as_tsv=format_output_as_tsv,
     ).print_task_history()

--- a/packages/divbase-cli/src/divbase_cli/display_task_history.py
+++ b/packages/divbase-cli/src/divbase_cli/display_task_history.py
@@ -140,11 +140,11 @@ class TaskHistoryDisplayManager:
             else:
                 error_msg = str(task.result) or "Unknown error"
 
-            return self._wrap_with_colour(str(error_msg), colour)
+            return self._colourize_if_enabled(str(error_msg), colour)
 
         if isinstance(task.result, BcftoolsQueryTaskResult):
             result_message = f"Output file ready for download: {task.result.output_file}"
-            return self._wrap_with_colour(result_message, colour)
+            return self._colourize_if_enabled(result_message, colour)
 
         elif isinstance(task.result, SampleMetadataQueryTaskResult):
             result_message = (
@@ -152,7 +152,7 @@ class TaskHistoryDisplayManager:
                 f"VCF files containing the sample IDs:\n  {task.result.unique_filenames}\n"
                 f"Sample metadata query:\n  {task.result.query_message}"
             )
-            return self._wrap_with_colour(result_message, colour)
+            return self._colourize_if_enabled(result_message, colour)
 
         elif isinstance(task.result, DimensionUpdateTaskResult):
             result_message = (
@@ -160,7 +160,7 @@ class TaskHistoryDisplayManager:
                 f"VCF files skipped by this job (previous DivBase-generated result VCFs):\n  {task.result.VCF_files_skipped}\n"
                 f"VCF files that have been deleted from the project and now are dropped from the index:\n  {task.result.VCF_files_deleted}"
             )
-            return self._wrap_with_colour(result_message, colour)
+            return self._colourize_if_enabled(result_message, colour)
 
         if isinstance(task.result, dict) and ("exc_type" in task.result or "error" in task.result):
             # Handle any remaining error dicts that weren't caught by FAILURE state check
@@ -173,12 +173,12 @@ class TaskHistoryDisplayManager:
                     error_msg = str(exc_message)
                 else:
                     error_msg = task.result.get("exc_type", "Unknown error")
-            return self._wrap_with_colour(str(error_msg), colour)
+            return self._colourize_if_enabled(str(error_msg), colour)
 
         result_message = str(task.result)
-        return self._wrap_with_colour(result_message, colour)
+        return self._colourize_if_enabled(result_message, colour)
 
-    def _wrap_with_colour(self, text: str, colour: str) -> str:
+    def _colourize_if_enabled(self, text: str, colour: str) -> str:
         if self.format_output_as_tsv:
             return text
         return f"[{colour}]{text}[/{colour}]"

--- a/packages/divbase-cli/src/divbase_cli/display_task_history.py
+++ b/packages/divbase-cli/src/divbase_cli/display_task_history.py
@@ -5,6 +5,7 @@ from zoneinfo import ZoneInfo
 from rich.console import Console
 from rich.table import Table
 
+from divbase_cli.utils import print_rich_table_as_tsv
 from divbase_lib.api_schemas.task_history import (
     BcftoolsQueryTaskResult,
     DimensionUpdateTaskResult,
@@ -40,12 +41,14 @@ class TaskHistoryDisplayManager:
         project_name: str | None,
         mode: str,
         display_limit: int = 10,
+        format_output_as_tsv: bool = False,
     ):
         self.task_items = task_items
         self.user_email = user_email
         self.project_name = project_name
         self.mode = mode
         self.display_limit = display_limit
+        self.format_output_as_tsv = format_output_as_tsv
 
     def print_task_history(self) -> None:
         """Display the task history fetched from the results backend in a formatted table."""
@@ -63,8 +66,11 @@ class TaskHistoryDisplayManager:
             else:
                 state = "QUEUING"
 
-            colour = self.STATE_COLOURS.get(state, "white")
-            state_with_colour = f"[{colour}]{state}[/{colour}]"
+            if self.format_output_as_tsv:
+                state_with_colour = state
+            else:
+                colour = self.STATE_COLOURS.get(state, "white")
+                state_with_colour = f"[{colour}]{state}[/{colour}]"
 
             submitter = task.submitter_email or "Unknown"
             result = self._format_result(task, state)
@@ -78,8 +84,12 @@ class TaskHistoryDisplayManager:
                 str(task.runtime if task.runtime is not None else "N/A"),
                 result,
             )
-        console = Console()
-        console.print(table)
+
+        if self.format_output_as_tsv:
+            print_rich_table_as_tsv(table=table)
+        else:
+            console = Console()
+            console.print(table)
 
     def _create_task_history_table(self):
         """
@@ -130,10 +140,15 @@ class TaskHistoryDisplayManager:
             else:
                 error_msg = str(task.result) or "Unknown error"
 
+            error_msg = str(error_msg)
+            if self.format_output_as_tsv:
+                return error_msg
             return f"[{colour}]{error_msg}[/{colour}]"
 
         if isinstance(task.result, BcftoolsQueryTaskResult):
             result_message = f"Output file ready for download: {task.result.output_file}"
+            if self.format_output_as_tsv:
+                return result_message
             return f"[{colour}]{result_message}[/{colour}]"
 
         elif isinstance(task.result, SampleMetadataQueryTaskResult):
@@ -142,6 +157,8 @@ class TaskHistoryDisplayManager:
                 f"VCF files containing the sample IDs:\n  {task.result.unique_filenames}\n"
                 f"Sample metadata query:\n  {task.result.query_message}"
             )
+            if self.format_output_as_tsv:
+                return result_message
             return f"[{colour}]{result_message}[/{colour}]"
 
         elif isinstance(task.result, DimensionUpdateTaskResult):
@@ -150,6 +167,8 @@ class TaskHistoryDisplayManager:
                 f"VCF files skipped by this job (previous DivBase-generated result VCFs):\n  {task.result.VCF_files_skipped}\n"
                 f"VCF files that have been deleted from the project and now are dropped from the index:\n  {task.result.VCF_files_deleted}"
             )
+            if self.format_output_as_tsv:
+                return result_message
             return f"[{colour}]{result_message}[/{colour}]"
 
         if isinstance(task.result, dict) and ("exc_type" in task.result or "error" in task.result):
@@ -163,9 +182,14 @@ class TaskHistoryDisplayManager:
                     error_msg = str(exc_message)
                 else:
                     error_msg = task.result.get("exc_type", "Unknown error")
+            error_msg = str(error_msg)
+            if self.format_output_as_tsv:
+                return error_msg
             return f"[{colour}]{error_msg}[/{colour}]"
 
         result_message = str(task.result)
+        if self.format_output_as_tsv:
+            return result_message
         return f"[{colour}]{result_message}[/{colour}]"
 
     def _to_cet(self, timestamp_str):

--- a/packages/divbase-cli/src/divbase_cli/display_task_history.py
+++ b/packages/divbase-cli/src/divbase_cli/display_task_history.py
@@ -140,16 +140,11 @@ class TaskHistoryDisplayManager:
             else:
                 error_msg = str(task.result) or "Unknown error"
 
-            error_msg = str(error_msg)
-            if self.format_output_as_tsv:
-                return error_msg
-            return f"[{colour}]{error_msg}[/{colour}]"
+            return self._wrap_with_colour(str(error_msg), colour)
 
         if isinstance(task.result, BcftoolsQueryTaskResult):
             result_message = f"Output file ready for download: {task.result.output_file}"
-            if self.format_output_as_tsv:
-                return result_message
-            return f"[{colour}]{result_message}[/{colour}]"
+            return self._wrap_with_colour(result_message, colour)
 
         elif isinstance(task.result, SampleMetadataQueryTaskResult):
             result_message = (
@@ -157,9 +152,7 @@ class TaskHistoryDisplayManager:
                 f"VCF files containing the sample IDs:\n  {task.result.unique_filenames}\n"
                 f"Sample metadata query:\n  {task.result.query_message}"
             )
-            if self.format_output_as_tsv:
-                return result_message
-            return f"[{colour}]{result_message}[/{colour}]"
+            return self._wrap_with_colour(result_message, colour)
 
         elif isinstance(task.result, DimensionUpdateTaskResult):
             result_message = (
@@ -167,9 +160,7 @@ class TaskHistoryDisplayManager:
                 f"VCF files skipped by this job (previous DivBase-generated result VCFs):\n  {task.result.VCF_files_skipped}\n"
                 f"VCF files that have been deleted from the project and now are dropped from the index:\n  {task.result.VCF_files_deleted}"
             )
-            if self.format_output_as_tsv:
-                return result_message
-            return f"[{colour}]{result_message}[/{colour}]"
+            return self._wrap_with_colour(result_message, colour)
 
         if isinstance(task.result, dict) and ("exc_type" in task.result or "error" in task.result):
             # Handle any remaining error dicts that weren't caught by FAILURE state check
@@ -182,15 +173,15 @@ class TaskHistoryDisplayManager:
                     error_msg = str(exc_message)
                 else:
                     error_msg = task.result.get("exc_type", "Unknown error")
-            error_msg = str(error_msg)
-            if self.format_output_as_tsv:
-                return error_msg
-            return f"[{colour}]{error_msg}[/{colour}]"
+            return self._wrap_with_colour(str(error_msg), colour)
 
         result_message = str(task.result)
+        return self._wrap_with_colour(result_message, colour)
+
+    def _wrap_with_colour(self, text: str, colour: str) -> str:
         if self.format_output_as_tsv:
-            return result_message
-        return f"[{colour}]{result_message}[/{colour}]"
+            return text
+        return f"[{colour}]{text}[/{colour}]"
 
     def _to_cet(self, timestamp_str):
         """

--- a/tests/e2e_integration/cli_commands/test_task_history_cli.py
+++ b/tests/e2e_integration/cli_commands/test_task_history_cli.py
@@ -1,6 +1,8 @@
 import datetime
 import re
 from contextlib import contextmanager
+from csv import reader
+from io import StringIO
 from time import sleep
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -142,6 +144,8 @@ def capture_task_history_manager():
     assertions can be made on the actually content of the class and not the rich table output,
     which is sensitive to formatting errors (newlines, whitespaces, etc).
     """
+
+    # TODO now that there is a --tsv option for divbase-cli task-history cmds, this fixture and the tests that call it could be refeactored to assert on the tsv output instead.
     captured_manager = None
 
     def capture_display_manager(self):
@@ -195,6 +199,48 @@ def test_edit_user_can_only_see_their_own_task_history(CONSTANTS, logged_in_edit
 
     assert CONSTANTS["TEST_USERS"]["edit user"]["email"] in user_emails
     assert CONSTANTS["TEST_USERS"]["manage user"]["email"] not in user_emails
+
+
+def test_task_history_user_tsv_output_is_parseable_and_plain(
+    logged_in_edit_user_with_existing_config,
+):
+    """Test that task-history user --tsv emits parseable TSV (not rich table output)."""
+    result_history = runner.invoke(app, "task-history user --tsv --limit 50")
+    assert result_history.exit_code == 0
+
+    # Rich table border chars should not be present in TSV mode.
+    for border_char in ("│", "┃", "┏", "┓", "┗", "┛", "┡", "┩", "┠", "┨", "┬", "┴", "┼", "┯", "┷", "━", "─"):
+        assert border_char not in result_history.stdout
+
+    rows = list(
+        reader(StringIO(result_history.stdout), delimiter="\t")
+    )  # use stringIO to handle newlines in stdout output
+    assert len(rows) > 1  # Header + at least one data row
+
+    expected_headers = [
+        "Submitting user",
+        "Task ID",
+        "State",
+        "Created at",
+        "Started at",
+        "Runtime (s)",
+        "Result",
+    ]
+    assert rows[0] == expected_headers
+
+    for row in rows[1:]:
+        assert len(row) == len(expected_headers)
+
+        task_id = row[1]
+        state = row[2]
+        result_text = row[6]
+
+        assert task_id.isdigit()
+        assert (
+            "[" not in state and "]" not in state
+        )  # Rich markup tags such as [green]...[/green] should not be present in TSV state cell
+        assert state in {"QUEUING", "STARTED", "SUCCESS", "FAILURE", "RETRY", "REVOKED"}
+        assert result_text != ""
 
 
 def test_admin_user_can_see_all_task_history(CONSTANTS, logged_in_admin_with_existing_config):


### PR DESCRIPTION
This is a small PR that adds the option to output tsv from the `divbase-cli task-history` commands. We talked about it recently, and I think it would be useful to have this for writing the e2e tests for the new VCF data. 

This makes use of the same helpers and constants as e.g. `divbase-cli files ls` so it is pretty straightforward. Only thing that needed consideration is that the task-history commands have their own class that handles the table display, including dynamically changing colours depending on values, etc.

There are many existing tests that parse the `rich` table output with `capture_task_history_manager` in `tests/e2e_integration/cli_commands/test_task_history_cli.py`. I did not change them now, but it could be relevant to see if those test could run task history with `--tsv` instead for easier-to-parse outputs. 