### PR TITLE
SQ-792: Setup structured logging for deployed environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,10 @@ scripts/benchmarking/results
 htmlcov/
 docker/coverage-data/
 
+# log files written by docker compose, if env var set to do so (by default no)
+docker/logs/*
+!docker/logs/.gitkeep
+
 #MacOS artifacts
 .DS_Store
 

--- a/docker/divbase_compose.yaml
+++ b/docker/divbase_compose.yaml
@@ -213,6 +213,7 @@ services:
       db-migrator:
         condition: service_completed_successfully
     environment:
+      - DIVBASE_ENV=local_dev
       - SYNC_DATABASE_URL=postgresql+psycopg2://divbase_user:badpassword@postgres:5432/divbase_db
       - S3_ENDPOINT_URL=http://host.docker.internal:9000
       - S3_CRON_SERVICE_ACCOUNT_ACCESS_KEY=s3-cron-service-account

--- a/docker/divbase_compose.yaml
+++ b/docker/divbase_compose.yaml
@@ -77,6 +77,8 @@ services:
           target: /app/.venv/lib/python3.13/site-packages/divbase_lib/
         - action: rebuild
           path: ../uv.lock
+    volumes:
+      - ./logs:/logs
     # NOTE: celery beat runs here ("-B"), in production it is run as a separate service
     # NOTE: Worker quick takes any non-specified tasks (with -Q "celery" being the default queue), 
     command: ["-Q", "quick,celery", "--hostname=worker-quick@%h", "--concurrency=1", "-B"]
@@ -90,6 +92,8 @@ services:
     depends_on: *worker-api-depends
     environment: *worker-env
     develop: *watch-celery-src
+    volumes:
+      - ./logs:/logs
     command: ["-Q", "long", "--hostname=worker-long@%h", "--concurrency=1"]
     networks: *internal-network
     ports:
@@ -174,6 +178,7 @@ services:
     volumes:
       - ../packages/divbase-api/src/divbase_api/migrations:/app/migrations # this is to get the migration scripts which are generated inside the container 
       - ../packages/divbase-api/src/divbase_api/alembic.ini:/app/alembic.ini
+      - ./logs:/logs
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/core/health"]
       interval: 5s
@@ -218,6 +223,8 @@ services:
       - S3_ENDPOINT_URL=http://host.docker.internal:9000
       - S3_CRON_SERVICE_ACCOUNT_ACCESS_KEY=s3-cron-service-account
       - S3_CRON_SERVICE_ACCOUNT_SECRET_KEY=badpassword
+    volumes:
+      - ./logs:/logs
     networks:
       - internal
   postgres:

--- a/docker/divbase_compose.yaml
+++ b/docker/divbase_compose.yaml
@@ -159,6 +159,7 @@ services:
       - ../packages/divbase-api/src/divbase_api/migrations:/app/migrations:ro
       - ../packages/divbase-api/src/divbase_api/alembic.ini:/app/alembic.ini:ro
   fastapi:
+    hostname: divbase-api
     build:
       context: ..
       dockerfile: docker/fastapi.dockerfile

--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -30,3 +30,9 @@ The config can handle both:
 ## Logging in deployed environments
 
 This is handled by our private [divbase argocd](https://github.com/ScilifelabDataCentre/argocd-divbase) repo. See the docs there for information.
+
+## Logging to file (by default turned off)
+
+File logging is optional (for api + worker) and controlled by setting `LOG_TO_FILE=1` in the docker compose file.
+
+If on, it will write logs to `{REPO_ROOT}/docker/logs/` in local dev (as well as stdout).

--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -1,0 +1,32 @@
+# Logging
+
+DivBase API and worker use [structlog](https://www.structlog.org/en/stable/). divbase-lib and divbase-cli use the standard library logging module.
+
+Structlog used so we can output logs as JSON in deployed environments for easier to parse logs with e.g. grafana alloy. In `local_dev` and `test` environments, we render logs not as JSON, so easier to read.
+
+We don't use structlog in the cli or lib modules as would add unnecessary bloat.
+
+## Configuration
+
+- Shared logging configuration lives in packages/divbase-api/src/divbase_api/logging_config.py.
+- Logging is configured through configure_logging(log_level, environment).
+
+The config can handle both:
+
+- structlog logger calls.
+- non-structlog stdlib logging calls (for example from third-party libraries like uvicorn).
+
+## Special context added to logs
+
+1. Request context (API)
+
+    - We use middleware to create and bind (aka add) a uuid to all logging events associated with a specific request. This uuid is then present in all logs covering the entire request-response cycle - so easy to filter.
+    - The uuid is included as a response header ("X-Request-ID") and divbase-cli includes the response header in the user facing error message if an error occurs, so we can use this for debugging.
+
+2. Task context (worker)
+
+    - celery signals used to bind (aka add) the task id to all logging events associated with a specific task, - again same idea as above, nice for filtering.
+
+## Logging in deployed environments
+
+This is handled by our private [divbase argocd](https://github.com/ScilifelabDataCentre/argocd-divbase) repo. See the docs there for information.

--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -8,10 +8,7 @@ We don't use structlog in the cli or lib modules as would add unnecessary bloat.
 
 ## Configuration
 
-- Shared logging configuration lives in packages/divbase-api/src/divbase_api/logging_config.py.
-- Logging is configured through configure_logging(log_level, environment).
-
-The config can handle both:
+Shared logging configuration lives in logging_config.py. The config can handle both:
 
 - structlog logger calls.
 - non-structlog stdlib logging calls (for example from third-party libraries like uvicorn).
@@ -27,12 +24,13 @@ The config can handle both:
 
     - celery signals used to bind (aka add) the task id to all logging events associated with a specific task, - again same idea as above, nice for filtering.
 
-## Logging in deployed environments
-
-This is handled by our private [divbase argocd](https://github.com/ScilifelabDataCentre/argocd-divbase) repo. See the docs there for information.
-
 ## Logging to file (by default turned off)
 
-File logging is optional (for api + worker) and controlled by setting `LOG_TO_FILE=1` in the docker compose file.
+File logging is optional (for api + worker) and controlled by setting `LOG_TO_FILE=1` and is by default turned off.
 
-If on, it will write logs to `{REPO_ROOT}/docker/logs/` in local dev (as well as stdout).
+- If on, it will write logs to /logs/ in deployed environments (as well as stdout).
+- If on, it will write logs to `{REPO_ROOT}/docker/logs/` in local dev (as well as stdout).
+
+There is a celery cron job in place to clean up old logs files (older than 30 days).
+
+At time of writing, in deployed environments, logs are written to a shared PVC and stdout. In local dev logs are only written to stdout. At some point it would be nice to setup loki, grafana alloy and grafana for log aggregation and visualisation in the deployed environments. If that happens then the logging to file approch can most likely be deleted.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,7 @@ nav:
     - Writing E2E Tests for VCF Results Checksums: development/writing_e2e_tests_for_vcf_results_checksums.md
     - Monitoring and observability: development/monitoring_and_observability.md
     - "Monitoring: Celery Worker Metrics": development/worker_metrics.md
+    - Logging: development/logging.md
     - Contributing to DivBase development: CONTRIBUTING.md
     - Security Policy: SECURITY.md
   - Releases: releases/index.md

--- a/packages/divbase-api/pyproject.toml
+++ b/packages/divbase-api/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "psutil==7.2.2",
     "boto3==1.42.56",
     "divbase-lib", # always uses version in repo, handled by uv
+    "structlog>=25.5.0",
 ]
 
 [build-system]

--- a/packages/divbase-api/src/divbase_api/admin_panel.py
+++ b/packages/divbase-api/src/divbase_api/admin_panel.py
@@ -6,12 +6,12 @@ These overrides are on methods inside BaseModelView (parent of ModelView, which 
 """
 
 import json
-import logging
 import pickle
 from datetime import datetime, timezone
 from typing import Any
 from zoneinfo import ZoneInfo
 
+import structlog
 from fastapi import FastAPI, Response
 from pydantic import SecretStr
 from sqlalchemy.exc import IntegrityError
@@ -47,7 +47,7 @@ from divbase_api.models.task_history import CeleryTaskMeta, TaskHistoryDB, TaskS
 from divbase_api.models.users import UserDB
 from divbase_api.security import TokenType, get_password_hash
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 PAGINATION_DEFAULTS = [5, 10, 25, -1]  # (for number of items per page toggle)
 

--- a/packages/divbase-api/src/divbase_api/api_config.py
+++ b/packages/divbase-api/src/divbase_api/api_config.py
@@ -26,6 +26,7 @@ class GeneralSettings:
     mkdocs_site_url: str = os.getenv("MKDOCS_SITE_URL", "NOT_SET")
     user_support_email: EmailStr = os.getenv("USER_SUPPORT_EMAIL", "NOT_SET")
     log_level: str = os.getenv("LOG_LEVEL", "INFO").upper()
+    log_to_file: bool = os.getenv("LOG_TO_FILE", "0") == "1"
     first_admin_email: str = os.getenv("FIRST_ADMIN_EMAIL", "NOT_SET")
     first_admin_password: SecretStr = SecretStr(os.getenv("FIRST_ADMIN_PASSWORD", "NOT_SET"))
 

--- a/packages/divbase-api/src/divbase_api/api_config.py
+++ b/packages/divbase-api/src/divbase_api/api_config.py
@@ -14,8 +14,7 @@ from dataclasses import dataclass, field
 from pydantic import EmailStr, SecretStr
 
 from divbase_lib import __version__ as lib_version
-
-LOCAL_DEV_ENVIRONMENTS = ["local_dev", "test"]
+from divbase_lib.divbase_constants import LOCAL_DEV_ENVIRONMENTS
 
 
 @dataclass

--- a/packages/divbase-api/src/divbase_api/api_config.py
+++ b/packages/divbase-api/src/divbase_api/api_config.py
@@ -101,7 +101,7 @@ class EmailSettings:
     password_reset_expires_seconds: int = int(os.getenv("PASSWORD_RESET_EXPIRES_SECONDS", 60 * 60))  # 1 hour
 
     def __post_init__(self):
-        """Handle enviroment specific email settings."""
+        """Handle environment specific email settings."""
         if os.getenv("DIVBASE_ENV") in LOCAL_DEV_ENVIRONMENTS:
             # using mailpit in docker stack
             self.smtp_server = "mailpit"

--- a/packages/divbase-api/src/divbase_api/crud/auth.py
+++ b/packages/divbase-api/src/divbase_api/crud/auth.py
@@ -2,9 +2,9 @@
 Authentication-related CRUD operations.
 """
 
-import logging
 from datetime import datetime, timezone
 
+import structlog
 from fastapi import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -15,7 +15,7 @@ from divbase_api.models.users import UserDB
 from divbase_api.schemas.users import UserPasswordUpdate
 from divbase_api.security import TokenType, get_password_hash, verify_password, verify_token
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 async def authenticate_user(db: AsyncSession, email: str, password: str) -> UserDB:

--- a/packages/divbase-api/src/divbase_api/crud/personal_access_tokens.py
+++ b/packages/divbase-api/src/divbase_api/crud/personal_access_tokens.py
@@ -2,9 +2,9 @@
 CRUD operations for Personal Access Tokens (PATs).
 """
 
-import logging
 from datetime import datetime, timedelta, timezone
 
+import structlog
 from pydantic import SecretStr
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -18,7 +18,7 @@ from divbase_api.security import generate_personal_access_token, hash_personal_a
 
 PAT_MAX_ACTIVE_TOKENS = 5
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 async def create_personal_access_token(

--- a/packages/divbase-api/src/divbase_api/crud/project_versions.py
+++ b/packages/divbase-api/src/divbase_api/crud/project_versions.py
@@ -8,9 +8,9 @@ version IDs (hashes) at that point in time.
 Version entries are created and managed via the API.
 """
 
-import logging
 from datetime import datetime, timezone
 
+import structlog
 from fastapi import HTTPException
 from fastapi.concurrency import run_in_threadpool
 from sqlalchemy import select
@@ -34,7 +34,7 @@ from divbase_lib.api_schemas.project_versions import (
     UpdateVersionResponse,
 )
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 async def add_project_version(

--- a/packages/divbase-api/src/divbase_api/crud/revoked_tokens.py
+++ b/packages/divbase-api/src/divbase_api/crud/revoked_tokens.py
@@ -2,8 +2,7 @@
 CRUD operations for working with revoked JWTs.
 """
 
-import logging
-
+import structlog
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -11,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from divbase_api.models.revoked_tokens import RevokedTokenDB, TokenRevokeReason
 from divbase_api.security import TokenType
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 async def token_is_revoked(db: AsyncSession, token_jti: str) -> bool:

--- a/packages/divbase-api/src/divbase_api/crud/s3.py
+++ b/packages/divbase-api/src/divbase_api/crud/s3.py
@@ -2,9 +2,8 @@
 Crud operations for the S3 endpoints
 """
 
-import logging
-
 import boto3
+import structlog
 from botocore.exceptions import ClientError
 from pydantic import SecretStr
 
@@ -13,7 +12,7 @@ from divbase_api.services.pre_signed_urls import S3PreSignedService
 from divbase_api.services.s3_client import S3FileManager
 from divbase_lib.api_schemas.s3 import FileChecksumResponse
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def get_s3_file_manager() -> S3FileManager:

--- a/packages/divbase-api/src/divbase_api/crud/task_history.py
+++ b/packages/divbase-api/src/divbase_api/crud/task_history.py
@@ -2,8 +2,7 @@
 CRUD operations for task history.
 """
 
-import logging
-
+import structlog
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -11,7 +10,7 @@ from divbase_api.models.projects import ProjectMembershipDB, ProjectRoles
 from divbase_api.models.task_history import CeleryTaskMeta, TaskHistoryDB, TaskStartedAtDB
 from divbase_api.models.users import UserDB
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 async def get_tasks_pg(

--- a/packages/divbase-api/src/divbase_api/crud/vcf_dimensions.py
+++ b/packages/divbase-api/src/divbase_api/crud/vcf_dimensions.py
@@ -6,15 +6,14 @@ There are separate VCF dimensions CRUD functions for the Celery workers in
 packages/divbase-api/src/divbase_api/worker/crud_dimensions.py
 """
 
-import logging
-
+import structlog
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from divbase_api.models.vcf_dimensions import SkippedVCFDB, VCFMetadataDB, VCFMetadataSamplesDB, VCFMetadataScaffoldsDB
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 async def get_vcf_metadata_by_project_async(db: AsyncSession, project_id: int) -> dict:

--- a/packages/divbase-api/src/divbase_api/db.py
+++ b/packages/divbase-api/src/divbase_api/db.py
@@ -2,10 +2,10 @@
 Handles connection between FastAPI and the postgresql db.
 """
 
-import logging
 from pathlib import Path
 from typing import AsyncGenerator
 
+import structlog
 from alembic import command
 from alembic.config import Config
 from alembic.util.exc import DatabaseNotAtHead
@@ -16,7 +16,7 @@ from divbase_api.api_config import api_settings
 from divbase_api.crud.users import create_user, get_all_users
 from divbase_api.schemas.users import UserCreate
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 # NOTE: The creation of the AsyncSessionLocal should only occur once, when the module is loaded.

--- a/packages/divbase-api/src/divbase_api/deps.py
+++ b/packages/divbase-api/src/divbase_api/deps.py
@@ -18,9 +18,9 @@ so all checks in the sub-dependency function are ran when you use this dependenc
 (see here: https://fastapi.tiangolo.com/yo/advanced/security/oauth2-scopes/#dependency-tree-and-scopes)
 """
 
-import logging
 from typing import Annotated
 
+import structlog
 from fastapi import Cookie, Depends, Response
 from fastapi.security import OAuth2PasswordBearer
 from pydantic import SecretStr, ValidationError
@@ -40,7 +40,7 @@ from divbase_api.security import TokenType, create_token
 from divbase_lib.api_schemas.personal_access_tokens import PATPermissions
 from divbase_lib.divbase_constants import PAT_TOKEN_PREFIX
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 # Returned for JWT tokens and PATs which are not scoped.
 # Effectively means the token has whatever permissions the user has.

--- a/packages/divbase-api/src/divbase_api/divbase_api.py
+++ b/packages/divbase-api/src/divbase_api/divbase_api.py
@@ -39,7 +39,12 @@ from divbase_api.routes.task_history import task_history_router
 from divbase_api.routes.vcf_dimensions import vcf_dimensions_router
 from divbase_lib.divbase_constants import LOCAL_DEV_ENVIRONMENTS
 
-configure_logging(log_level=api_settings.general.log_level, environment=api_settings.general.environment)
+configure_logging(
+    log_level=api_settings.general.log_level,
+    environment=api_settings.general.environment,
+    log_to_file=api_settings.general.log_to_file,
+    service_name="divbase_api",
+)
 logger = structlog.get_logger(__name__)
 
 

--- a/packages/divbase-api/src/divbase_api/divbase_api.py
+++ b/packages/divbase-api/src/divbase_api/divbase_api.py
@@ -41,7 +41,7 @@ from divbase_api.routes.vcf_dimensions import vcf_dimensions_router
 from divbase_lib.divbase_constants import LOCAL_DEV_ENVIRONMENTS
 
 configure_logging(log_level=api_settings.general.log_level, environment=api_settings.general.environment)
-logger = structlog.get_logger()
+logger = structlog.get_logger(__name__)
 
 
 @asynccontextmanager

--- a/packages/divbase-api/src/divbase_api/divbase_api.py
+++ b/packages/divbase-api/src/divbase_api/divbase_api.py
@@ -3,11 +3,11 @@ The API server for DivBase.
 """
 
 import logging
-import sys
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import AsyncGenerator
 
+import structlog
 import uvicorn
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
@@ -28,6 +28,7 @@ from divbase_api.frontend_routes.core import fr_core_router
 from divbase_api.frontend_routes.personal_access_tokens import fr_pat_router
 from divbase_api.frontend_routes.profile import fr_profile_router
 from divbase_api.frontend_routes.projects import fr_projects_router
+from divbase_api.logging_config import configure_logging
 from divbase_api.middleware import register_middleware
 from divbase_api.routes.admin import admin_router
 from divbase_api.routes.auth import auth_router
@@ -39,9 +40,8 @@ from divbase_api.routes.task_history import task_history_router
 from divbase_api.routes.vcf_dimensions import vcf_dimensions_router
 from divbase_lib.divbase_constants import LOCAL_DEV_ENVIRONMENTS
 
-logging.basicConfig(level=api_settings.general.log_level, handlers=[logging.StreamHandler(sys.stderr)])
-
-logger = logging.getLogger(__name__)
+configure_logging(log_level=api_settings.general.log_level, environment=api_settings.general.environment)
+logger = structlog.get_logger()
 
 
 @asynccontextmanager

--- a/packages/divbase-api/src/divbase_api/divbase_api.py
+++ b/packages/divbase-api/src/divbase_api/divbase_api.py
@@ -31,7 +31,7 @@ from divbase_api.frontend_routes.projects import fr_projects_router
 from divbase_api.middleware import register_middleware
 from divbase_api.routes.admin import admin_router
 from divbase_api.routes.auth import auth_router
-from divbase_api.routes.core import core_router
+from divbase_api.routes.core import HealthCheckFilter, core_router
 from divbase_api.routes.project_versions import project_version_router
 from divbase_api.routes.queries import query_router
 from divbase_api.routes.s3 import s3_router
@@ -47,7 +47,11 @@ logger = logging.getLogger(__name__)
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Lifespan context manager that handles startup and shutdown of API server"""
     # startup
-    logger.info("Starting up DivBase API...")
+    logger.info(f"Starting up DivBase API in environment: {api_settings.general.environment}")
+
+    if api_settings.general.environment not in LOCAL_DEV_ENVIRONMENTS:
+        logging.getLogger("uvicorn.access").addFilter(HealthCheckFilter())
+        logger.info("Non-development environment detected, 200 health check logs will be filtered out.")
 
     api_settings.validate_api_settings()
     logger.info("All API settings are correctly set.")

--- a/packages/divbase-api/src/divbase_api/divbase_api.py
+++ b/packages/divbase-api/src/divbase_api/divbase_api.py
@@ -2,7 +2,6 @@
 The API server for DivBase.
 """
 
-import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import AsyncGenerator
@@ -32,7 +31,7 @@ from divbase_api.logging_config import configure_logging
 from divbase_api.middleware import register_middleware
 from divbase_api.routes.admin import admin_router
 from divbase_api.routes.auth import auth_router
-from divbase_api.routes.core import HealthCheckFilter, core_router
+from divbase_api.routes.core import core_router
 from divbase_api.routes.project_versions import project_version_router
 from divbase_api.routes.queries import query_router
 from divbase_api.routes.s3 import s3_router
@@ -49,10 +48,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Lifespan context manager that handles startup and shutdown of API server"""
     # startup
     logger.info(f"Starting up DivBase API in environment: {api_settings.general.environment}")
-
-    if api_settings.general.environment not in LOCAL_DEV_ENVIRONMENTS:
-        logging.getLogger("uvicorn.access").addFilter(HealthCheckFilter())
-        logger.info("Non-development environment detected, 200 health check logs will be filtered out.")
 
     api_settings.validate_api_settings()
     logger.info("All API settings are correctly set.")

--- a/packages/divbase-api/src/divbase_api/divbase_api.py
+++ b/packages/divbase-api/src/divbase_api/divbase_api.py
@@ -106,7 +106,7 @@ app.include_router(s3_router, prefix="/api/v1/s3", tags=["s3"])
 app.include_router(task_history_router, prefix="/api/v1/task-history", tags=["task-history"])
 app.include_router(vcf_dimensions_router, prefix="/api/v1/vcf-dimensions", tags=["vcf-dimensions"])
 if api_settings.general.environment in LOCAL_DEV_ENVIRONMENTS:
-    # not needed in deployed enviroments, so no need to expose it.
+    # not needed in deployed environments, so no need to expose it.
     app.include_router(admin_router, prefix="/api/v1/admin", tags=["admin"])
 
 app.include_router(fr_auth_router, prefix="", include_in_schema=False)

--- a/packages/divbase-api/src/divbase_api/divbase_api.py
+++ b/packages/divbase-api/src/divbase_api/divbase_api.py
@@ -14,7 +14,7 @@ from fastapi.staticfiles import StaticFiles
 
 from divbase_api import __version__ as divbase_version
 from divbase_api.admin_panel import register_admin_panel
-from divbase_api.api_config import LOCAL_DEV_ENVIRONMENTS, api_settings
+from divbase_api.api_config import api_settings
 from divbase_api.crud.s3 import validate_s3_service_account
 from divbase_api.db import (
     check_db_migrations_up_to_date,
@@ -37,6 +37,7 @@ from divbase_api.routes.queries import query_router
 from divbase_api.routes.s3 import s3_router
 from divbase_api.routes.task_history import task_history_router
 from divbase_api.routes.vcf_dimensions import vcf_dimensions_router
+from divbase_lib.divbase_constants import LOCAL_DEV_ENVIRONMENTS
 
 logging.basicConfig(level=api_settings.general.log_level, handlers=[logging.StreamHandler(sys.stderr)])
 

--- a/packages/divbase-api/src/divbase_api/exception_handlers.py
+++ b/packages/divbase-api/src/divbase_api/exception_handlers.py
@@ -12,7 +12,7 @@ The idea of centralising this is to:
 import structlog
 from fastapi import FastAPI, Request, status
 from fastapi.exceptions import RequestValidationError
-from fastapi.responses import JSONResponse, RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse, Response
 from starlette.exceptions import HTTPException
 
 from divbase_api.db import get_db
@@ -64,6 +64,17 @@ async def get_current_user_from_request_object(request: Request) -> UserDB | Non
     return user
 
 
+def add_request_id_header(request: Request, response: Response) -> Response:
+    """
+    helper fn to add X-Request-ID to an existing response
+    Needed in the global/generic exception handler as the middleware approach of appending the header will not work as won't be reached.
+    """
+    request_id = getattr(request.state, "request_id", None)
+    if request_id:
+        response.headers["X-Request-ID"] = request_id
+    return response
+
+
 async def render_error_page(
     request: Request,
     message: str,
@@ -71,7 +82,7 @@ async def render_error_page(
 ):
     """Helper function to render the generic error page for frontend requests."""
     current_user = await get_current_user_from_request_object(request)
-    return templates.TemplateResponse(
+    response = templates.TemplateResponse(
         request=request,
         name="error.html",
         context={
@@ -81,6 +92,7 @@ async def render_error_page(
         },
         status_code=status_code,
     )
+    return add_request_id_header(request, response)
 
 
 async def global_exception_handler(request: Request, exc: Exception):
@@ -90,12 +102,15 @@ async def global_exception_handler(request: Request, exc: Exception):
     logger.error(f"Unexpected Error occurred for: {request.method} {request.url.path}: {exc}", exc_info=True)
 
     if is_api_request(request):
-        return JSONResponse(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            content={
-                "detail": "An unexpected error occurred. Please try again later.",
-                "type": "server_error",
-            },
+        return add_request_id_header(
+            request,
+            JSONResponse(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                content={
+                    "detail": "An unexpected error occurred. Please try again later.",
+                    "type": "server_error",
+                },
+            ),
         )
     else:
         return await render_error_page(
@@ -344,6 +359,7 @@ async def generic_http_exception_handler(request: Request, exc: HTTPException):
         return JSONResponse(
             status_code=exc.status_code,
             content={"detail": exc.detail, "type": "http_error"},
+            headers=exc.headers,
         )
 
     # (Frontend request)

--- a/packages/divbase-api/src/divbase_api/exception_handlers.py
+++ b/packages/divbase-api/src/divbase_api/exception_handlers.py
@@ -9,8 +9,7 @@ The idea of centralising this is to:
 3. Less work/duplication in the routes themselves, just raise the exception and the handler makes it pretty.
 """
 
-import logging
-
+import structlog
 from fastapi import FastAPI, Request, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, RedirectResponse
@@ -43,7 +42,7 @@ from divbase_api.exceptions import (
 from divbase_api.frontend_routes.core import templates
 from divbase_api.models.users import UserDB
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def is_api_request(request: Request) -> bool:

--- a/packages/divbase-api/src/divbase_api/frontend_routes/auth.py
+++ b/packages/divbase-api/src/divbase_api/frontend_routes/auth.py
@@ -2,8 +2,7 @@
 Frontend routes for authentication-related pages.
 """
 
-import logging
-
+import structlog
 from fastapi import APIRouter, BackgroundTasks, Depends, Form, Query, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
 from pydantic import SecretStr, ValidationError
@@ -38,7 +37,7 @@ from divbase_api.services.email_sender import (
     send_verification_email,
 )
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 fr_auth_router = APIRouter()

--- a/packages/divbase-api/src/divbase_api/frontend_routes/personal_access_tokens.py
+++ b/packages/divbase-api/src/divbase_api/frontend_routes/personal_access_tokens.py
@@ -4,10 +4,10 @@ Frontend routes for user to manage their personal access tokens (PATs).
 All routes here should rely on get_current_user_from_cookie dependency to ensure user is logged in.
 """
 
-import logging
 from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
+import structlog
 from fastapi import APIRouter, BackgroundTasks, Depends, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -29,7 +29,7 @@ from divbase_lib.api_schemas.personal_access_tokens import PATPermissions
 
 fr_pat_router = APIRouter()
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 PAT_EXPIRE_OPTIONS = {
     "1": "1 day",

--- a/packages/divbase-api/src/divbase_api/frontend_routes/profile.py
+++ b/packages/divbase-api/src/divbase_api/frontend_routes/profile.py
@@ -4,8 +4,7 @@ Frontend routes for user to manage their profile/account.
 All routes here should rely on get_current_user_from_cookie dependency to ensure user is logged in.
 """
 
-import logging
-
+import structlog
 from fastapi import APIRouter, Depends, Form, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
 from pydantic import ValidationError
@@ -22,7 +21,7 @@ from divbase_api.schemas.users import UserUpdate
 
 fr_profile_router = APIRouter()
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 @fr_profile_router.get("/", response_class=HTMLResponse, status_code=status.HTTP_200_OK)

--- a/packages/divbase-api/src/divbase_api/frontend_routes/projects.py
+++ b/packages/divbase-api/src/divbase_api/frontend_routes/projects.py
@@ -9,8 +9,7 @@ For these routes you'll likely want to use one of the following dependencies:
     (You need to validate their role is sufficient for what they're trying to do though).
 """
 
-import logging
-
+import structlog
 from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -33,7 +32,7 @@ from divbase_api.models.projects import ProjectDB, ProjectRoles
 from divbase_api.models.users import UserDB
 from divbase_api.schemas.projects import UserProjectResponse
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 fr_projects_router = APIRouter()
 

--- a/packages/divbase-api/src/divbase_api/logging_config.py
+++ b/packages/divbase-api/src/divbase_api/logging_config.py
@@ -19,7 +19,7 @@ import structlog
 
 from divbase_lib.divbase_constants import LOCAL_DEV_ENVIRONMENTS
 
-DEFAULT_LOG_DIR = Path("/logs")
+LOG_FILES_DIR = Path("/logs")
 
 
 class SkipHealthyApiChecksFilter(logging.Filter):
@@ -93,7 +93,7 @@ def configure_logging(log_level: str, environment: str, service_name: str, log_t
     handlers: list[logging.Handler] = [stream_handler]
     if log_to_file:
         instance_name = socket.gethostname()
-        log_file = DEFAULT_LOG_DIR / f"{service_name}-{instance_name}.log"
+        log_file = LOG_FILES_DIR / f"{service_name}-{instance_name}.log"
 
         file_handler = RotatingFileHandler(
             filename=log_file,

--- a/packages/divbase-api/src/divbase_api/logging_config.py
+++ b/packages/divbase-api/src/divbase_api/logging_config.py
@@ -1,0 +1,78 @@
+"""
+Structlog configuration for the divbase-api.
+
+- local-dev/test environments: ConsoleRenderer
+- All other environments: JSON for Loki.
+
+Usage in all modules is simply:
+logger = structlog.get_logger()
+(but if standard logging is used in some places, it will still work fine)
+"""
+
+import logging
+import sys
+
+import structlog
+
+from divbase_lib.divbase_constants import LOCAL_DEV_ENVIRONMENTS
+
+
+def configure_logging(log_level: str, environment: str) -> None:
+    """
+    At app startup, configure structlogging
+
+    This covers logs from both:
+    1. structlog logs (logs from calls to structlog.get_logger())
+    2. non-structlog logs (e.g. 3rd party lib logs like uvicorn, sqlalchemy, or if there are standard logging calls from our codebase)
+
+    See this guide:
+    https://wazaari.dev/blog/fastapi-structlog-integration
+    """
+    if environment in LOCAL_DEV_ENVIRONMENTS:
+        renderer: structlog.types.Processor = structlog.dev.ConsoleRenderer(colors=False)
+    else:
+        renderer = structlog.processors.JSONRenderer()
+
+    level = getattr(logging, log_level.upper())
+
+    shared_processors: list[structlog.types.Processor] = [
+        structlog.contextvars.merge_contextvars,
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.StackInfoRenderer(),
+    ]
+
+    structlog.configure(
+        processors=[
+            *shared_processors,
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(level),
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
+
+    # handles non structlog logs
+    formatter = structlog.stdlib.ProcessorFormatter(
+        foreign_pre_chain=shared_processors,
+        processors=[
+            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+            renderer,
+        ],
+    )
+
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(formatter)
+
+    root_logger = logging.getLogger()
+    root_logger.handlers = [handler]
+    root_logger.setLevel(level)
+
+    # prevents double logging by uvicorn
+    for name in ("uvicorn", "uvicorn.error", "uvicorn.access", "uvicorn.asgi"):
+        uvicorn_logger = logging.getLogger(name)
+        uvicorn_logger.handlers.clear()
+        uvicorn_logger.propagate = True

--- a/packages/divbase-api/src/divbase_api/logging_config.py
+++ b/packages/divbase-api/src/divbase_api/logging_config.py
@@ -10,20 +10,41 @@ logger = structlog.get_logger(__name__)
 """
 
 import logging
+import socket
 import sys
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
 
 import structlog
 
 from divbase_lib.divbase_constants import LOCAL_DEV_ENVIRONMENTS
 
+DEFAULT_LOG_DIR = Path("/logs")
 
-def configure_logging(log_level: str, environment: str) -> None:
+
+class SkipHealthyApiChecksFilter(logging.Filter):
+    """
+    Filter out uvicorn access logs for the healthcheck endpoint from being stored/logged (otherwise noisy)
+    only those that are healthy are filtered, and this is not applied to the stream handler, just the file handler (if used).
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.name != "uvicorn.access":
+            return True
+
+        message = record.getMessage()
+        return "/api/v1/core/health" not in message or "200" not in message
+
+
+def configure_logging(log_level: str, environment: str, service_name: str, log_to_file: bool = False) -> None:
     """
     At app startup, configure structlogging
 
     This covers logs from both:
     1. structlog logs (logs from calls to structlog.get_logger())
     2. non-structlog logs (e.g. 3rd party lib logs like uvicorn, sqlalchemy, or if there are standard logging calls from our codebase)
+
+    You can optionally also log to file (in addition to stdout).
 
     See this guide:
     https://wazaari.dev/blog/fastapi-structlog-integration
@@ -66,11 +87,29 @@ def configure_logging(log_level: str, environment: str) -> None:
         ],
     )
 
-    handler = logging.StreamHandler(sys.stderr)
-    handler.setFormatter(formatter)
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setFormatter(formatter)
+
+    handlers: list[logging.Handler] = [stream_handler]
+    if log_to_file:
+        instance_name = socket.gethostname()
+        log_file = DEFAULT_LOG_DIR / f"{service_name}-{instance_name}.log"
+
+        file_handler = RotatingFileHandler(
+            filename=log_file,
+            maxBytes=10 * 1024 * 1024,  # 10 MB
+            backupCount=2,
+            encoding="utf-8",
+        )
+        file_handler.setFormatter(formatter)
+        if service_name == "divbase_api":
+            # don't store 200 health check logs in the file
+            file_handler.addFilter(SkipHealthyApiChecksFilter())
+
+        handlers.append(file_handler)
 
     root_logger = logging.getLogger()
-    root_logger.handlers = [handler]
+    root_logger.handlers = handlers
     root_logger.setLevel(level)
 
     # prevents double logging by uvicorn

--- a/packages/divbase-api/src/divbase_api/logging_config.py
+++ b/packages/divbase-api/src/divbase_api/logging_config.py
@@ -29,7 +29,9 @@ def configure_logging(log_level: str, environment: str) -> None:
     https://wazaari.dev/blog/fastapi-structlog-integration
     """
     if environment in LOCAL_DEV_ENVIRONMENTS:
-        renderer: structlog.types.Processor = structlog.dev.ConsoleRenderer(colors=False)
+        renderer: structlog.types.Processor = structlog.dev.ConsoleRenderer(
+            colors=False, exception_formatter=structlog.dev.plain_traceback
+        )
     else:
         renderer = structlog.processors.JSONRenderer()
 

--- a/packages/divbase-api/src/divbase_api/logging_config.py
+++ b/packages/divbase-api/src/divbase_api/logging_config.py
@@ -5,7 +5,7 @@ Structlog configuration for the divbase-api.
 - All other environments: JSON for Loki.
 
 Usage in all modules is simply:
-logger = structlog.get_logger()
+logger = structlog.get_logger(__name__)
 (but if standard logging is used in some places, it will still work fine)
 """
 

--- a/packages/divbase-api/src/divbase_api/middleware.py
+++ b/packages/divbase-api/src/divbase_api/middleware.py
@@ -41,11 +41,7 @@ class RequestContextMiddleware(BaseHTTPMiddleware):
         request_id = str(uuid.uuid4())
         request.state.request_id = request_id
         structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(
-            request_id=request_id,
-            method=request.method,
-            path=request.url.path,
-        )
+        structlog.contextvars.bind_contextvars(request_id=request_id)
         response = await call_next(request)
         response.headers["X-Request-ID"] = request_id
         return response

--- a/packages/divbase-api/src/divbase_api/middleware.py
+++ b/packages/divbase-api/src/divbase_api/middleware.py
@@ -18,9 +18,9 @@ from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
-from divbase_api.api_config import LOCAL_DEV_ENVIRONMENTS, api_settings
+from divbase_api.api_config import api_settings
 from divbase_api.services.validate_cli_versions import cli_version_outdated
-from divbase_lib.divbase_constants import CLI_VERSION_HEADER_KEY
+from divbase_lib.divbase_constants import CLI_VERSION_HEADER_KEY, LOCAL_DEV_ENVIRONMENTS
 
 IMAGE_FONT_EXTENSIONS = [".webp", ".svg", ".jpg", ".jpeg", ".png", ".woff", ".woff2", ".ttf"]
 CSS_JS_EXTENSIONS = [".css", ".js"]

--- a/packages/divbase-api/src/divbase_api/middleware.py
+++ b/packages/divbase-api/src/divbase_api/middleware.py
@@ -39,6 +39,7 @@ class RequestContextMiddleware(BaseHTTPMiddleware):
         - user can give us the "X-Request-ID" in error report and we can search logs more easily.
         """
         request_id = str(uuid.uuid4())
+        request.state.request_id = request_id
         structlog.contextvars.clear_contextvars()
         structlog.contextvars.bind_contextvars(
             request_id=request_id,

--- a/packages/divbase-api/src/divbase_api/middleware.py
+++ b/packages/divbase-api/src/divbase_api/middleware.py
@@ -9,8 +9,10 @@ NOTE: The following are not implemented here as they are handled by the ingress 
 - Autoredirect from HTTP to HTTPS (so no need for HTTPSRedirectMiddleware)
 """
 
+import uuid
 from urllib.parse import urlparse
 
+import structlog
 from fastapi import FastAPI
 from fastapi.middleware.gzip import GZipMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
@@ -24,6 +26,28 @@ from divbase_lib.divbase_constants import CLI_VERSION_HEADER_KEY, LOCAL_DEV_ENVI
 
 IMAGE_FONT_EXTENSIONS = [".webp", ".svg", ".jpg", ".jpeg", ".png", ".woff", ".woff2", ".ttf"]
 CSS_JS_EXTENSIONS = [".css", ".js"]
+
+
+class RequestContextMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        """
+        To every request that comes in, we bind(aka add) context into structlog's contextvars so every log line
+        produced during the request-response cycle automatically includes these fields.
+
+        2 benefits:
+        - correlate every log message to the request.
+        - user can give us the "X-Request-ID" in error report and we can search logs more easily.
+        """
+        request_id = str(uuid.uuid4())
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(
+            request_id=request_id,
+            method=request.method,
+            path=request.url.path,
+        )
+        response = await call_next(request)
+        response.headers["X-Request-ID"] = request_id
+        return response
 
 
 class CustomHeaderMiddleware(BaseHTTPMiddleware):
@@ -101,4 +125,5 @@ def register_middleware(app: FastAPI) -> None:
     app.add_middleware(middleware_class=GZipMiddleware, minimum_size=1000, compresslevel=5)
     app.add_middleware(CustomHeaderMiddleware)
     app.add_middleware(CLIVersionMiddleware)
+    app.add_middleware(RequestContextMiddleware)
     app.add_middleware(middleware_class=TrustedHostMiddleware, allowed_hosts=allowed_hosts)

--- a/packages/divbase-api/src/divbase_api/routes/admin.py
+++ b/packages/divbase-api/src/divbase_api/routes/admin.py
@@ -2,7 +2,7 @@
 Admin routes for basic tasks like creating users and projects.
 This is only used in local development and testing to automatically setup test/dev data.
 
-These routes are turned off in other enviroments.
+These routes are turned off in other environments.
 We manage deployed instances of DivBase via the admin-panel (which uses starlette-admin).
 
 All routes in here should depend on get_current_admin_user.

--- a/packages/divbase-api/src/divbase_api/routes/admin.py
+++ b/packages/divbase-api/src/divbase_api/routes/admin.py
@@ -8,8 +8,7 @@ We manage deployed instances of DivBase via the admin-panel (which uses starlett
 All routes in here should depend on get_current_admin_user.
 """
 
-import logging
-
+import structlog
 from fastapi import APIRouter, BackgroundTasks, Depends, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -23,7 +22,7 @@ from divbase_api.schemas.projects import ProjectCreate, ProjectMembershipRespons
 from divbase_api.schemas.users import UserCreate, UserResponse
 from divbase_api.services.email_sender import send_test_email
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 admin_router = APIRouter()
 

--- a/packages/divbase-api/src/divbase_api/routes/auth.py
+++ b/packages/divbase-api/src/divbase_api/routes/auth.py
@@ -5,9 +5,9 @@ This is for CLI/API clients to login and get tokens for authenticated requests.
 Frontend routes are located in frontend_routes/auth.py
 """
 
-import logging
 from typing import Annotated
 
+import structlog
 from fastapi import APIRouter, Depends, status
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -28,7 +28,7 @@ from divbase_lib.api_schemas.auth import (
 )
 from divbase_lib.api_schemas.personal_access_tokens import PATPermissions
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 auth_router = APIRouter()
 

--- a/packages/divbase-api/src/divbase_api/routes/core.py
+++ b/packages/divbase-api/src/divbase_api/routes/core.py
@@ -4,8 +4,6 @@ Core API routes for divbase, including health checks and announcements.
 Note that unlike every other API route these routes are not behind authentication...
 """
 
-import logging
-
 from fastapi import APIRouter, Depends, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -16,17 +14,6 @@ from divbase_lib.api_schemas.announcements import AnnouncementResponse
 from divbase_lib.divbase_constants import CLI_VERSION_HEADER_KEY
 
 core_router = APIRouter()
-
-
-class HealthCheckFilter(logging.Filter):
-    """
-    Suppress uvicorn access log entries for the health check endpoint.
-    To avoid filling up logs with these requests.
-    We only filter out the 200 OK health check responses, so any failed health checks will still be logged.
-    """
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        return '/api/v1/core/health HTTP/1.1" 200' not in record.getMessage()
 
 
 @core_router.get("/health", status_code=status.HTTP_200_OK, response_model=dict[str, str])

--- a/packages/divbase-api/src/divbase_api/routes/core.py
+++ b/packages/divbase-api/src/divbase_api/routes/core.py
@@ -4,6 +4,8 @@ Core API routes for divbase, including health checks and announcements.
 Note that unlike every other API route these routes are not behind authentication...
 """
 
+import logging
+
 from fastapi import APIRouter, Depends, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -14,6 +16,17 @@ from divbase_lib.api_schemas.announcements import AnnouncementResponse
 from divbase_lib.divbase_constants import CLI_VERSION_HEADER_KEY
 
 core_router = APIRouter()
+
+
+class HealthCheckFilter(logging.Filter):
+    """
+    Suppress uvicorn access log entries for the health check endpoint.
+    To avoid filling up logs with these requests.
+    We only filter out the 200 OK health check responses, so any failed health checks will still be logged.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return '/api/v1/core/health HTTP/1.1" 200' not in record.getMessage()
 
 
 @core_router.get("/health", status_code=status.HTTP_200_OK, response_model=dict[str, str])

--- a/packages/divbase-api/src/divbase_api/routes/project_versions.py
+++ b/packages/divbase-api/src/divbase_api/routes/project_versions.py
@@ -5,9 +5,9 @@ Project versions are the state of all files in a project at a given time point.
 These are user defined points in time (like a checkpoint/commit) that the user can refer back to later.
 """
 
-import logging
 from typing import Annotated
 
+import structlog
 from fastapi import APIRouter, Depends, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -37,7 +37,7 @@ from divbase_lib.api_schemas.project_versions import (
     UpdateVersionResponse,
 )
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 project_version_router = APIRouter()
 

--- a/packages/divbase-api/src/divbase_api/routes/queries.py
+++ b/packages/divbase-api/src/divbase_api/routes/queries.py
@@ -2,9 +2,8 @@
 API routes for query operations.
 """
 
-import logging
-
 import celery
+import structlog
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -39,7 +38,7 @@ from divbase_lib.exceptions import (
     TaskUserError,
 )
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 query_router = APIRouter()
 

--- a/packages/divbase-api/src/divbase_api/routes/queries.py
+++ b/packages/divbase-api/src/divbase_api/routes/queries.py
@@ -3,14 +3,12 @@ API routes for query operations.
 """
 
 import logging
-import sys
 
 import celery
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.concurrency import run_in_threadpool
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from divbase_api.api_config import api_settings
 from divbase_api.crud.projects import has_required_role
 from divbase_api.crud.queue_status import check_queue_closed_for_new_tasks
 from divbase_api.crud.task_history import create_task_history_entry, update_task_history_entry_with_celery_task_id
@@ -40,8 +38,6 @@ from divbase_lib.exceptions import (
     SidecarSampleIDError,
     TaskUserError,
 )
-
-logging.basicConfig(level=api_settings.general.log_level, handlers=[logging.StreamHandler(sys.stderr)])
 
 logger = logging.getLogger(__name__)
 

--- a/packages/divbase-api/src/divbase_api/routes/s3.py
+++ b/packages/divbase-api/src/divbase_api/routes/s3.py
@@ -8,9 +8,9 @@ we need to use has_required_role to check if they have permission to do the oper
 - To avoid blocking the event loop when using the S3 client (boto3 is a sync SDK), we run these operations in a threadpool.
 """
 
-import logging
 from typing import Annotated
 
+import structlog
 from fastapi import APIRouter, Body, Depends, HTTPException, status
 from fastapi.concurrency import run_in_threadpool
 
@@ -44,7 +44,7 @@ from divbase_lib.api_schemas.s3 import (
 )
 from divbase_lib.divbase_constants import MAX_S3_API_BATCH_SIZE
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 s3_router = APIRouter()
 

--- a/packages/divbase-api/src/divbase_api/routes/task_history.py
+++ b/packages/divbase-api/src/divbase_api/routes/task_history.py
@@ -2,8 +2,7 @@
 API routes for task history operations.
 """
 
-import logging
-
+import structlog
 from fastapi import APIRouter, Depends, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing_extensions import Annotated
@@ -20,7 +19,7 @@ from divbase_api.services.task_history import (
 )
 from divbase_lib.api_schemas.task_history import TaskHistoryResult
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 task_history_router = APIRouter()
 

--- a/packages/divbase-api/src/divbase_api/routes/vcf_dimensions.py
+++ b/packages/divbase-api/src/divbase_api/routes/vcf_dimensions.py
@@ -2,8 +2,7 @@
 API routes for VCF dimensions (technical metadata) operations.
 """
 
-import logging
-
+import structlog
 from fastapi import APIRouter, Depends, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -31,7 +30,7 @@ from divbase_lib.api_schemas.vcf_dimensions import (
     DimensionUpdateKwargs,
 )
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 vcf_dimensions_router = APIRouter()
 

--- a/packages/divbase-api/src/divbase_api/scripts/cleanup_expired_files.py
+++ b/packages/divbase-api/src/divbase_api/scripts/cleanup_expired_files.py
@@ -25,22 +25,23 @@ For versioned buckets (which DivBase uses):
             This would not be expected since the file was soft deleted and the user expected it to be gone.
 """
 
-import logging
 import os
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 
 import stamina
+import structlog
 from botocore.exceptions import ConnectionError as BotoCoreConnectionError
 from pydantic import SecretStr
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import selectinload, sessionmaker
 
+from divbase_api.logging_config import configure_logging
 from divbase_api.models.projects import ProjectDB
 from divbase_api.services.s3_client import S3_BATCH_SIZE, S3FileManager
 from divbase_lib.divbase_constants import QUERY_RESULTS_FILE_PREFIX
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class HardDeletePartialFailureError(Exception):
@@ -59,6 +60,8 @@ DEFAULT_SOFT_DELETED_FILES_RETENTION_DAYS = 30
 class CronJobConfig:
     """Config for the cron job"""
 
+    environment: str = os.environ["DIVBASE_ENV"]
+    logging_level: str = os.getenv("LOG_LEVEL", "INFO").upper()
     db_url: SecretStr = field(default_factory=lambda: SecretStr(os.environ["SYNC_DATABASE_URL"]))
     endpoint_url: str = field(default_factory=lambda: os.environ["S3_ENDPOINT_URL"])
     access_key: SecretStr = field(default_factory=lambda: SecretStr(os.environ["S3_CRON_SERVICE_ACCOUNT_ACCESS_KEY"]))
@@ -327,9 +330,9 @@ def delete_expired_non_results_files(
 
 def main() -> None:
     """See docstring at top of file for description"""
-    logging.basicConfig(level=logging.INFO)
-
     job_config = CronJobConfig()
+    configure_logging(log_level=job_config.logging_level, environment=job_config.environment)
+
     s3_file_manager = S3FileManager(
         url=job_config.endpoint_url,
         access_key=job_config.access_key.get_secret_value(),
@@ -338,6 +341,7 @@ def main() -> None:
 
     logger.info(
         f"Starting hard_delete_expired_files cron job with configuration settings: \n"
+        f"environment={job_config.environment} \n"
         f"endpoint_url={job_config.endpoint_url} \n"
         f"soft_deleted_files_retention_days={job_config.soft_deleted_files_retention_days} \n"
         f"task_files_retention_days={job_config.task_files_retention_days}",

--- a/packages/divbase-api/src/divbase_api/scripts/cleanup_expired_files.py
+++ b/packages/divbase-api/src/divbase_api/scripts/cleanup_expired_files.py
@@ -62,6 +62,7 @@ class CronJobConfig:
 
     environment: str = os.environ["DIVBASE_ENV"]
     logging_level: str = os.getenv("LOG_LEVEL", "INFO").upper()
+    log_to_file: bool = os.getenv("LOG_TO_FILE", "0") == "1"
     db_url: SecretStr = field(default_factory=lambda: SecretStr(os.environ["SYNC_DATABASE_URL"]))
     endpoint_url: str = field(default_factory=lambda: os.environ["S3_ENDPOINT_URL"])
     access_key: SecretStr = field(default_factory=lambda: SecretStr(os.environ["S3_CRON_SERVICE_ACCOUNT_ACCESS_KEY"]))
@@ -331,7 +332,12 @@ def delete_expired_non_results_files(
 def main() -> None:
     """See docstring at top of file for description"""
     job_config = CronJobConfig()
-    configure_logging(log_level=job_config.logging_level, environment=job_config.environment)
+    configure_logging(
+        log_level=job_config.logging_level,
+        environment=job_config.environment,
+        log_to_file=job_config.log_to_file,
+        service_name="divbase_cron_cleanup_expired_files",
+    )
 
     s3_file_manager = S3FileManager(
         url=job_config.endpoint_url,

--- a/packages/divbase-api/src/divbase_api/services/bcftools_helpers.py
+++ b/packages/divbase-api/src/divbase_api/services/bcftools_helpers.py
@@ -1,10 +1,11 @@
 # Shared bcftools helpers used by both VCF dimension indexing and query orchestration in DivBase.
 
-import logging
 import os
 import shlex
 import subprocess
 from pathlib import Path
+
+import structlog
 
 from divbase_lib.exceptions import (
     BcftoolsCommandError,
@@ -12,7 +13,7 @@ from divbase_lib.exceptions import (
     TaskUserError,
 )
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 BCFTOOLS_CONTAINER_NAME = (
     "divbase-worker-quick-1"  # for synchronous tasks in local dev, use this container name to find the container ID

--- a/packages/divbase-api/src/divbase_api/services/email_sender.py
+++ b/packages/divbase-api/src/divbase_api/services/email_sender.py
@@ -12,18 +12,18 @@ The compiled HTML templates are used by Jinja2 to create the emails actual conte
 To compile the templates I used the vscode "MJML Official" extension.
 """
 
-import logging
 from pathlib import Path
 from time import sleep
 from typing import Any
 
 import emails
+import structlog
 from jinja2 import Template
 
 from divbase_api.api_config import api_settings
 from divbase_api.security import TokenType, create_token
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def render_email_template(template_name: str, context: dict[str, Any]) -> str:

--- a/packages/divbase-api/src/divbase_api/services/metadata_queries.py
+++ b/packages/divbase-api/src/divbase_api/services/metadata_queries.py
@@ -1,10 +1,10 @@
-import logging
 import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import pandas as pd
+import structlog
 
 from divbase_api.services.vcf_queries import SampleFileMapping
 from divbase_api.worker.crud_dimensions import ProjectVCFDimensionsData
@@ -18,7 +18,7 @@ from divbase_lib.exceptions import (
 )
 from divbase_lib.metadata_validator import SharedMetadataValidator, ValidationCategory
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 ###

--- a/packages/divbase-api/src/divbase_api/services/pre_signed_urls.py
+++ b/packages/divbase-api/src/divbase_api/services/pre_signed_urls.py
@@ -6,10 +6,10 @@ Certain operations like "list files" etc... instead performed directly by the ba
 Pre-signed url approach not used when the request to s3 can be done in the (user to API) request-response cycle.
 """
 
-import logging
 from math import ceil
 
 import boto3
+import structlog
 from botocore.config import Config
 from fastapi import HTTPException, status
 
@@ -30,7 +30,7 @@ from divbase_lib.divbase_constants import (
     SINGLE_PART_UPLOAD_URL_EXPIRATION_SECONDS,
 )
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class S3PreSignedService:

--- a/packages/divbase-api/src/divbase_api/services/s3_client.py
+++ b/packages/divbase-api/src/divbase_api/services/s3_client.py
@@ -6,12 +6,12 @@ This class is a wrapper around the boto3 S3 client.
 See the 'docs/development/s3_transfers.md' for more info on how S3 transfers are handled.
 """
 
-import logging
 import os
 from pathlib import Path
 
 import boto3
 import stamina
+import structlog
 from boto3.s3.transfer import TransferConfig
 from botocore.config import Config
 from botocore.exceptions import ClientError
@@ -30,7 +30,7 @@ from divbase_lib.divbase_constants import S3_MULTIPART_CHUNK_SIZE, S3_MULTIPART_
 from divbase_lib.exceptions import ChecksumVerificationError
 from divbase_lib.s3_checksums import verify_downloaded_checksum
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 S3_BATCH_SIZE = 1000
 

--- a/packages/divbase-api/src/divbase_api/services/task_history.py
+++ b/packages/divbase-api/src/divbase_api/services/task_history.py
@@ -1,7 +1,8 @@
 import json
-import logging
 import pickle
 from datetime import datetime, timezone
+
+import structlog
 
 from divbase_lib.api_schemas.queries import (
     BcftoolsQueryKwargs,
@@ -14,7 +15,7 @@ from divbase_lib.api_schemas.task_history import (
 )
 from divbase_lib.api_schemas.vcf_dimensions import DimensionUpdateKwargs, DimensionUpdateTaskResult
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def deserialize_tasks_to_result(serialized_tasks: list[dict]) -> list[TaskHistoryResult]:

--- a/packages/divbase-api/src/divbase_api/services/validate_cli_versions.py
+++ b/packages/divbase-api/src/divbase_api/services/validate_cli_versions.py
@@ -6,7 +6,11 @@ OR
 On login, add announcement that a new version of the CLI can be installed.
 """
 
+import structlog
+
 from divbase_api.api_config import api_settings
+
+logger = structlog.get_logger(__name__)
 
 
 def _parse_version(version: str) -> list[int]:
@@ -39,7 +43,11 @@ def cli_version_outdated(cli_version: str, minimum_cli_version: str = api_settin
     Version strings are expected to be in the format "major.minor.patch" (e.g., "2.5.0").
     Any extra parts, e.g. alpha, beta, rc1, dev3 etc.. ignored.
     """
-    cli_parts = _parse_version(cli_version)
+    try:
+        cli_parts = _parse_version(cli_version)
+    except ValueError:
+        logger.warning(f"Received malformed CLI version: {cli_version}. Treating as outdated.")
+        return True
     min_parts = _parse_version(minimum_cli_version)
 
     for cli_part, min_part in zip(cli_parts, min_parts, strict=True):

--- a/packages/divbase-api/src/divbase_api/services/vcf_dimension_indexing.py
+++ b/packages/divbase-api/src/divbase_api/services/vcf_dimension_indexing.py
@@ -1,7 +1,8 @@
-import logging
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
+
+import structlog
 
 from divbase_api.services.bcftools_helpers import (
     _raise_task_user_error_from_bcftools_stderr,
@@ -9,7 +10,7 @@ from divbase_api.services.bcftools_helpers import (
     ensure_csi_index,
 )
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 @dataclass

--- a/packages/divbase-api/src/divbase_api/services/vcf_queries.py
+++ b/packages/divbase-api/src/divbase_api/services/vcf_queries.py
@@ -1,6 +1,5 @@
 import contextlib
 import datetime
-import logging
 import os
 import shlex
 import subprocess
@@ -9,6 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import psutil
+import structlog
 
 from divbase_api.services.bcftools_helpers import (
     BCFTOOLS_CONTAINER_NAME,
@@ -28,7 +28,7 @@ from divbase_lib.exceptions import (
 )
 from divbase_lib.utils import split_semicolon_bcftools_command_segments
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 ###
 ### Data structures for the query managers and their helper functions

--- a/packages/divbase-api/src/divbase_api/worker/cron_tasks.py
+++ b/packages/divbase-api/src/divbase_api/worker/cron_tasks.py
@@ -5,9 +5,9 @@ Hard deletion of soft deleted files is handled by a separate script: cleanup_exp
 This includes both results files and soft deleted files
 """
 
-import logging
 from datetime import datetime, timedelta, timezone
 
+import structlog
 from celery.schedules import crontab
 from sqlalchemy import delete, select, text, update
 
@@ -20,7 +20,7 @@ from divbase_api.worker.tasks import _create_s3_file_manager, app
 from divbase_api.worker.worker_config import worker_settings
 from divbase_api.worker.worker_db import SyncSessionLocal
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 @app.task(name="cron_tasks.cleanup_old_task_history")

--- a/packages/divbase-api/src/divbase_api/worker/cron_tasks.py
+++ b/packages/divbase-api/src/divbase_api/worker/cron_tasks.py
@@ -11,6 +11,7 @@ import structlog
 from celery.schedules import crontab
 from sqlalchemy import delete, select, text, update
 
+from divbase_api.logging_config import LOG_FILES_DIR
 from divbase_api.models.personal_access_tokens import PersonalAccessTokenDB
 from divbase_api.models.project_versions import ProjectVersionDB
 from divbase_api.models.projects import ProjectDB
@@ -233,6 +234,43 @@ def update_storage_usage_metrics():
     }
 
 
+@app.task(name="cron_tasks.remove_old_log_files")
+def remove_old_log_files(log_retention_days: int = worker_settings.cron.log_retention_days):
+    """
+    If a deployed enviroment is writing logs to files, this task will clean up outdated log files to prevent disk clutter.
+    NOTE: If loki/grafana alloy is setup, then this task can be removed.
+
+    Runs daily and deletes the log files based on when they were last modified.
+    """
+    if not LOG_FILES_DIR.exists():
+        logger.info(f"Log files directory does not exist, skipping cleanup: {LOG_FILES_DIR}")
+        return {
+            "status": "completed",
+            "number_of_log_files_deleted": "N/A - log directory does not exist",
+            "retention_days": log_retention_days,
+        }
+
+    cutoff_date = datetime.now(timezone.utc) - timedelta(days=log_retention_days)
+
+    numb_deleted = 0
+    for log_file in LOG_FILES_DIR.glob("*.log*"):
+        if not log_file.is_file():
+            continue
+
+        last_modified = datetime.fromtimestamp(log_file.stat().st_mtime, tz=timezone.utc)
+        if last_modified < cutoff_date:
+            log_file.unlink(missing_ok=True)
+            numb_deleted += 1
+
+    logger.info(f"Deleted {numb_deleted} log files older than {log_retention_days} days from {LOG_FILES_DIR}")
+
+    return {
+        "status": "completed",
+        "number_of_log_files_deleted": numb_deleted,
+        "retention_days": log_retention_days,
+    }
+
+
 # NOTE! If you add a new task here, make sure it starts with "cron_tasks"
 # Don't set to 2 AM or 3 AM due to daylight saving.
 # Timezone for job schedule is CET (defined in app in tasks.py).
@@ -256,5 +294,9 @@ app.conf.beat_schedule = {
     "update-storage-usage-metrics-daily": {
         "task": "cron_tasks.update_storage_usage_metrics",
         "schedule": crontab(hour=5, minute=30),  # Run daily at 5:30 AM CET
+    },
+    "clear-out-old-log-files-daily": {
+        "task": "cron_tasks.remove_old_log_files",
+        "schedule": crontab(hour=5, minute=35),  # Run daily at 5:35 AM CET
     },
 }

--- a/packages/divbase-api/src/divbase_api/worker/crud_dimensions.py
+++ b/packages/divbase-api/src/divbase_api/worker/crud_dimensions.py
@@ -5,10 +5,10 @@ packages/divbase-api/src/divbase_api/crud/vcf_dimensions.py
 """
 
 import dataclasses
-import logging
 from dataclasses import dataclass, field
 from typing import List
 
+import structlog
 from sqlalchemy import delete, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import selectinload
@@ -16,7 +16,7 @@ from sqlalchemy.orm.session import Session
 
 from divbase_api.models.vcf_dimensions import SkippedVCFDB, VCFMetadataDB, VCFMetadataSamplesDB, VCFMetadataScaffoldsDB
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 @dataclass

--- a/packages/divbase-api/src/divbase_api/worker/metrics.py
+++ b/packages/divbase-api/src/divbase_api/worker/metrics.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import socket
 import threading
@@ -9,11 +8,12 @@ from datetime import datetime, timedelta
 from typing import Optional
 
 import psutil
+import structlog
 from prometheus_client import Gauge, Info, start_http_server
 
 from divbase_api.worker.worker_config import worker_settings
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 WORKER_NAME = socket.gethostname()
 

--- a/packages/divbase-api/src/divbase_api/worker/tasks.py
+++ b/packages/divbase-api/src/divbase_api/worker/tasks.py
@@ -141,6 +141,8 @@ def config_loggers(*args, **kwargs) -> None:
     configure_logging(
         log_level=worker_settings.general.log_level,
         environment=worker_settings.general.environment,
+        log_to_file=worker_settings.general.log_to_file,
+        service_name="divbase_worker",
     )
 
 

--- a/packages/divbase-api/src/divbase_api/worker/tasks.py
+++ b/packages/divbase-api/src/divbase_api/worker/tasks.py
@@ -1,5 +1,4 @@
 import dataclasses
-import logging
 import os
 import time
 from datetime import datetime, timezone
@@ -8,11 +7,14 @@ from itertools import combinations
 from pathlib import Path
 
 import psutil
+import structlog
 from celery import Celery
 from celery.signals import (
     after_task_publish,
     beat_init,
     celeryd_init,
+    setup_logging,
+    task_postrun,
     task_prerun,
     worker_process_init,
 )
@@ -24,6 +26,7 @@ from divbase_api.exceptions import (
     TSVFileNotFoundInProjectError,
     VCFDimensionsEntryMissingError,
 )
+from divbase_api.logging_config import configure_logging
 from divbase_api.models.task_history import TaskHistoryDB, TaskStartedAtDB
 from divbase_api.services.metadata_queries import run_sidecar_metadata_query
 from divbase_api.services.s3_client import S3FileManager
@@ -61,7 +64,7 @@ from divbase_lib.api_schemas.vcf_dimensions import DimensionUpdateTaskResult
 from divbase_lib.divbase_constants import QUERY_RESULTS_FILE_PREFIX
 from divbase_lib.exceptions import DimensionsNotUpToDateWithBucketError, NoVCFFilesFoundError, TaskUserError
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 app = Celery(
@@ -130,6 +133,28 @@ app.conf.update(
     },
     result_expires=None,  # disables celery.backend_cleanup since Divbase uses custom cleanup tasks (see cron_tasks.py).
 )
+
+
+@setup_logging.connect
+def config_loggers(*args, **kwargs) -> None:
+    """Override Celery's default logging config with our custom structlog config"""
+    configure_logging(
+        log_level=worker_settings.general.log_level,
+        environment=worker_settings.general.environment,
+    )
+
+
+@task_prerun.connect
+def structlog_task_prerun(task_id, task, *args, **kwargs) -> None:
+    """Adds task_id and task_name into structlog context for each task"""
+    structlog.contextvars.clear_contextvars()
+    structlog.contextvars.bind_contextvars(task_id=task_id, task_name=task.name)
+
+
+@task_postrun.connect
+def structlog_task_postrun(*args, **kwargs) -> None:
+    """Clear structlog context after task run to prevent leakage into next task run by worker"""
+    structlog.contextvars.clear_contextvars()
 
 
 @celeryd_init.connect

--- a/packages/divbase-api/src/divbase_api/worker/worker_config.py
+++ b/packages/divbase-api/src/divbase_api/worker/worker_config.py
@@ -24,6 +24,7 @@ class WorkerGeneralSettings:
 
     environment: str = os.getenv("DIVBASE_ENV", "NOT_SET")
     log_level: str = os.getenv("LOG_LEVEL", "INFO").upper()
+    log_to_file: bool = os.getenv("LOG_TO_FILE", "0") == "1"
     sync_url: SecretStr = SecretStr(os.getenv("SYNC_DATABASE_URL", "NOT_SET"))
     broker_url: SecretStr = SecretStr(os.getenv("CELERY_BROKER_URL", "NOT_SET"))
     result_backend: SecretStr = SecretStr(os.getenv("CELERY_RESULT_BACKEND", "NOT_SET"))
@@ -62,6 +63,7 @@ class WorkerCronSettings:
     stuck_pending_hours: int = int(os.getenv("STUCK_PENDING_STATUS_HOURS", "168"))  # 168 h = 7 days
     stuck_started_hours: int = int(os.getenv("STUCK_STARTED_STATUS_HOURS", "168"))  # 168 h = 7 days
     task_retention_days: int = int(os.getenv("TASK_RETENTION_DAYS", "30"))
+    log_retention_days: int = int(os.getenv("LOG_RETENTION_DAYS", "30"))
     revoked_token_retention_days: int = int(os.getenv("REVOKED_TOKEN_RETENTION_DAYS", "7"))
     soft_deleted_project_version_retention_days: int = int(
         os.getenv("SOFT_DELETED_PROJECT_VERSION_RETENTION_DAYS", "30")

--- a/packages/divbase-api/src/divbase_api/worker/worker_config.py
+++ b/packages/divbase-api/src/divbase_api/worker/worker_config.py
@@ -15,6 +15,8 @@ from dataclasses import dataclass, field
 
 from pydantic import SecretStr
 
+from divbase_lib.divbase_constants import LOCAL_DEV_ENVIRONMENTS
+
 
 @dataclass
 class WorkerGeneralSettings:
@@ -93,7 +95,7 @@ class WorkerSettings:
                 if setting.get_secret_value() == "NOT_SET":
                     raise ValueError(f"A required environment variable was not set: {setting_name=}")
                 if (
-                    self.general.environment not in ["local_dev", "test"]
+                    self.general.environment not in LOCAL_DEV_ENVIRONMENTS
                     and setting.get_secret_value() == "badpassword"
                 ):
                     raise ValueError(

--- a/packages/divbase-api/src/divbase_api/worker/worker_config.py
+++ b/packages/divbase-api/src/divbase_api/worker/worker_config.py
@@ -23,6 +23,7 @@ class WorkerGeneralSettings:
     """General configuration settings for the worker."""
 
     environment: str = os.getenv("DIVBASE_ENV", "NOT_SET")
+    log_level: str = os.getenv("LOG_LEVEL", "INFO").upper()
     sync_url: SecretStr = SecretStr(os.getenv("SYNC_DATABASE_URL", "NOT_SET"))
     broker_url: SecretStr = SecretStr(os.getenv("CELERY_BROKER_URL", "NOT_SET"))
     result_backend: SecretStr = SecretStr(os.getenv("CELERY_RESULT_BACKEND", "NOT_SET"))

--- a/packages/divbase-api/src/divbase_api/worker/worker_db.py
+++ b/packages/divbase-api/src/divbase_api/worker/worker_db.py
@@ -9,7 +9,7 @@ from divbase_api.worker.worker_config import worker_settings
 
 # NOTE: As SyncSessionLocal is created at module load time,
 # both the API and WORKER applications will import an instance of the SyncSessionLocal object.
-# Both already need the enviroment variable SYNC_DATABASE_URL set.
+# Both already need the environment variable SYNC_DATABASE_URL set.
 # And as the overhead of creating the SyncSessionLocal object is low, we can just create it for both,
 # even if the API will not actually use it.
 sync_engine = create_engine(worker_settings.general.sync_url.get_secret_value(), echo=False, pool_pre_ping=True)

--- a/packages/divbase-cli/src/divbase_cli/cli_exceptions.py
+++ b/packages/divbase-cli/src/divbase_cli/cli_exceptions.py
@@ -42,17 +42,20 @@ class DivBaseAPIError(DivBaseCLIError):
         status_code: int = 500,
         http_method: str = "unknown",
         url: str = "unknown",
+        request_id: str = "unknown",
     ):
         self.status_code = status_code
         self.error_type = error_type
         self.error_details = error_details
         self.http_method = http_method
         self.url = url
+        self.request_id = request_id
         error_message = (
             f"DivBase Server returned an error response:\n"
             f"HTTP Status code: {status_code}\n"
             f"HTTP method: {http_method}\n"
             f"URL: {url}\n"
+            f"Request ID: {request_id}\n"
             f"Error type: {error_type}\n"
             f"Details: {error_details}\n"
         )

--- a/packages/divbase-cli/src/divbase_cli/user_auth.py
+++ b/packages/divbase-cli/src/divbase_cli/user_auth.py
@@ -109,16 +109,15 @@ def check_existing_session(divbase_url: str, config) -> int | None:
 
 def _handle_divbase_api_error(response: httpx.Response, http_method: str, url: str) -> None:
     """Handles custom display of a HTTP error response returned by DivBase API."""
+    request_id = response.headers.get("X-Request-ID", "unknown")
     try:
         response_body = response.json()
         error_details = response_body.get("detail", "No error message provided.")
         error_type = response_body.get("type", "unknown")
-        request_id = response.headers.get("X-Request-ID", "unknown")
     except (JSONDecodeError, ValueError):
         # most likely situation for this would be if the reverse proxy returns an error, not the server itself.
         error_details = response.text
         error_type = "unexpected_server_error"
-        request_id = "unknown"
 
     raise DivBaseAPIError(
         error_details=error_details,

--- a/packages/divbase-cli/src/divbase_cli/user_auth.py
+++ b/packages/divbase-cli/src/divbase_cli/user_auth.py
@@ -113,10 +113,12 @@ def _handle_divbase_api_error(response: httpx.Response, http_method: str, url: s
         response_body = response.json()
         error_details = response_body.get("detail", "No error message provided.")
         error_type = response_body.get("type", "unknown")
+        request_id = response.headers.get("X-Request-ID", "unknown")
     except (JSONDecodeError, ValueError):
         # most likely situation for this would be if the reverse proxy returns an error, not the server itself.
         error_details = response.text
         error_type = "unexpected_server_error"
+        request_id = "unknown"
 
     raise DivBaseAPIError(
         error_details=error_details,
@@ -124,6 +126,7 @@ def _handle_divbase_api_error(response: httpx.Response, http_method: str, url: s
         error_type=error_type,
         http_method=http_method,
         url=url,
+        request_id=request_id,
     ) from None
 
 

--- a/packages/divbase-lib/src/divbase_lib/divbase_constants.py
+++ b/packages/divbase-lib/src/divbase_lib/divbase_constants.py
@@ -55,5 +55,5 @@ CLI_VERSION_HEADER_KEY = "X-CLI-Version"
 # Personal Access Tokens (PATs) are used for passwordless auth with DivBase API
 PAT_TOKEN_PREFIX = "divbase_pat_"
 
-# Both divbase-api and divbase-worker(s) configs want to know if we are in a deployed enviroment or not
+# Both divbase-api and divbase-worker(s) configs want to know if we are in a deployed environment or not
 LOCAL_DEV_ENVIRONMENTS = ["local_dev", "test"]

--- a/packages/divbase-lib/src/divbase_lib/divbase_constants.py
+++ b/packages/divbase-lib/src/divbase_lib/divbase_constants.py
@@ -54,3 +54,6 @@ CLI_VERSION_HEADER_KEY = "X-CLI-Version"
 
 # Personal Access Tokens (PATs) are used for passwordless auth with DivBase API
 PAT_TOKEN_PREFIX = "divbase_pat_"
+
+# Both divbase-api and divbase-worker(s) configs want to know if we are in a deployed enviroment or not
+LOCAL_DEV_ENVIRONMENTS = ["local_dev", "test"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@
 Top-level pytest configuration for DivBase
 """
 
+from structlog.typing import EventDict
+
 REGRESSION_GUARD_PREFIX = "Regression guard failed:"
 
 
@@ -19,3 +21,13 @@ def pytest_addoption(parser):
         default=False,
         help="Enable running test coverage analysis for all tests, including those that run code inside docker containers. Do not use this flag directly, use the `scripts/run_tests_with_coverage.sh` to do coverage analysis",
     )
+
+
+def _text_in_logs(text: str, logs: list[EventDict]) -> bool:
+    """
+    Helper fn to check if a specific chunk of text is present in any of the log msgs/events.
+
+    This works with structlog's EventDict log structure.
+    Used in both e2e and unit tests, hence why it is here.
+    """
+    return any(text in log.get("event", "") for log in logs)

--- a/tests/e2e_integration/cli_commands/test_middleware.py
+++ b/tests/e2e_integration/cli_commands/test_middleware.py
@@ -44,7 +44,7 @@ def test_concurrent_health_requests_have_distinct_request_ids():
 def test_cli_version_middleware_rejects_outdated_cli_header():
     """
     Validate outdated CLI version header is rejected.
-    Should provide back a request ID header for both succesful and unsuccessful responses, and they should be different.
+    Should provide back a request ID header for both successful and unsuccessful responses, and they should be different.
     """
     outdated_response = httpx.get(HEALTH_URL, headers={CLI_VERSION_HEADER_KEY: "0.0.0"}, timeout=10)
     assert outdated_response.status_code == 400

--- a/tests/e2e_integration/cli_commands/test_middleware.py
+++ b/tests/e2e_integration/cli_commands/test_middleware.py
@@ -1,0 +1,90 @@
+"""
+E2E tests for API middleware behavior.
+
+These tests intentionally use real HTTP calls against the running docker test stack,
+with no patching/mocking, to validate middleware behavior end-to-end.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+from uuid import UUID
+
+import httpx
+
+from divbase_cli import __version__ as cli_version
+from divbase_cli.cli_config import cli_settings
+from divbase_lib.divbase_constants import CLI_VERSION_HEADER_KEY
+
+HEALTH_URL = f"{cli_settings.DIVBASE_API_URL}/v1/core/health"
+
+
+def _assert_valid_request_id(request_id: str) -> str:
+    try:
+        UUID(request_id)
+    except ValueError as e:
+        raise AssertionError(f"Invalid request ID, got: {request_id}. Expected a UUID string.") from e
+    return request_id
+
+
+def test_concurrent_health_requests_have_distinct_request_ids():
+    """Three overlapping requests should each receive their own request id."""
+    with ThreadPoolExecutor(max_workers=3) as executor:
+        responses = list(executor.map(lambda _: httpx.get(HEALTH_URL, timeout=10), range(3)))
+
+    request_ids: list[str] = []
+    for response in responses:
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
+        request_id = response.headers["X-Request-ID"]
+        _assert_valid_request_id(request_id)
+        request_ids.append(request_id)
+
+    assert len(set(request_ids)) == 3
+
+
+def test_cli_version_middleware_rejects_outdated_cli_header():
+    """
+    Validate outdated CLI version header is rejected.
+    Should provide back a request ID header for both succesful and unsuccessful responses, and they should be different.
+    """
+    outdated_response = httpx.get(HEALTH_URL, headers={CLI_VERSION_HEADER_KEY: "0.0.0"}, timeout=10)
+    assert outdated_response.status_code == 400
+    assert outdated_response.json()["type"] == "cli_version_outdated_error"
+    outdated_request_id = outdated_response.headers["X-Request-ID"]
+    _assert_valid_request_id(outdated_request_id)
+
+    ok_response = httpx.get(HEALTH_URL, headers={CLI_VERSION_HEADER_KEY: cli_version}, timeout=10)
+    assert ok_response.status_code == 200
+    assert ok_response.json() == {"status": "ok"}
+    ok_request_id = ok_response.headers["X-Request-ID"]
+    _assert_valid_request_id(ok_request_id)
+
+    assert outdated_request_id != ok_request_id
+
+
+def test_cli_version_header_is_optional():
+    """
+    Validate that:
+     - Missing CLI version header should be accepted.
+     - Malformed CLI version header should be rejected.
+    """
+    missing_header_response = httpx.get(HEALTH_URL, timeout=10)
+    assert missing_header_response.status_code == 200
+    assert missing_header_response.json() == {"status": "ok"}
+    missing_request_id = missing_header_response.headers["X-Request-ID"]
+    _assert_valid_request_id(missing_request_id)
+
+    malformed_header_response = httpx.get(
+        HEALTH_URL, headers={CLI_VERSION_HEADER_KEY: "not.a.valid.version"}, timeout=10
+    )
+    assert malformed_header_response.status_code == 400
+    assert malformed_header_response.json()["type"] == "cli_version_outdated_error"
+    malformed_request_id = malformed_header_response.headers["X-Request-ID"]
+    _assert_valid_request_id(malformed_request_id)
+
+
+def test_trusted_host_middleware_rejects_invalid_host():
+    """Requests with an invalid Host header should be rejected by TrustedHostMiddleware."""
+    response = httpx.get(HEALTH_URL, headers={"Host": "invalid.host.example"}, timeout=10)
+
+    assert response.status_code == 400
+    assert "Invalid host header" in response.text

--- a/tests/e2e_integration/cli_commands/test_query_cli.py
+++ b/tests/e2e_integration/cli_commands/test_query_cli.py
@@ -9,7 +9,6 @@ A project (CONSTANTS["QUERY_PROJECT"]) is made available with input files for th
 import csv
 import gzip
 import io
-import logging
 import re
 import time
 from pathlib import Path
@@ -24,7 +23,6 @@ from divbase_lib.divbase_constants import QUERY_RESULTS_FILE_PREFIX
 from divbase_lib.s3_checksums import MD5CheckSumFormat, calculate_md5_checksum
 from tests.conftest import REGRESSION_GUARD_PREFIX
 
-logging.basicConfig(level=logging.DEBUG)
 runner = CliRunner()
 
 _TASK_TERMINAL_STATES = {"SUCCESS", "FAILURE"}

--- a/tests/e2e_integration/queries_integration/test_bcftools_tasks.py
+++ b/tests/e2e_integration/queries_integration/test_bcftools_tasks.py
@@ -7,8 +7,10 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import structlog
 from celery import current_app
 from kombu.connection import Connection
+from structlog.testing import capture_logs
 from typer.testing import CliRunner
 
 from divbase_api.exceptions import VCFDimensionsEntryMissingError
@@ -18,8 +20,8 @@ from divbase_api.worker.tasks import bcftools_pipe_task
 from divbase_cli.divbase_cli import app
 from divbase_lib.divbase_constants import QUERY_RESULTS_FILE_PREFIX
 from divbase_lib.exceptions import DimensionsNotUpToDateWithBucketError, TaskUserError
+from tests.conftest import _text_in_logs
 
-logging.basicConfig(level=logging.DEBUG)
 runner = CliRunner()
 
 
@@ -472,7 +474,7 @@ def test_bcftools_pipe_cli_integration_with_eager_mode(
                 return self._stdout, self._stderr
 
         container_id = get_container_id("divbase-tests-worker-quick-1")
-        logger = logging.getLogger("divbase_lib.queries")
+        logger = structlog.get_logger()
         logger.debug(f"Executing command in container with ID: {container_id}")
         docker_cmd = ["docker", "exec", "-w", "/app/tests/fixtures", container_id, "bcftools"] + command.split()
         run_result = subprocess.run(
@@ -497,7 +499,7 @@ def test_bcftools_pipe_cli_integration_with_eager_mode(
             yield self
         finally:
             if self.temp_files:
-                logger = logging.getLogger("divbase_lib.queries")
+                logger = structlog.get_logger()
                 logger.info(f"Cleaning up {len(self.temp_files)} temporary files")
                 temp_files_with_path = [ensure_fixture_path(f) for f in self.temp_files]
                 self.cleanup_temp_files(temp_files_with_path)
@@ -575,7 +577,7 @@ def test_bcftools_pipe_cli_integration_with_eager_mode(
         Only delete the output file, using the correct path. Don't delete the fixtures, since they should persist.
         """
 
-        logger = logging.getLogger("divbase_api.worker.tasks")
+        logger = structlog.get_logger()
 
         if output_file is not None:
             output_file = ensure_fixture_path(str(output_file))
@@ -620,19 +622,20 @@ def test_bcftools_pipe_cli_integration_with_eager_mode(
                 new=patched_prepare_txt_with_divbase_header_for_vcf,
             ),
         ):
-            if not expect_success:
-                with pytest.raises((VCFDimensionsEntryMissingError, TaskUserError)) as e:
-                    bcftools_pipe_task(**params)
-                for msg in expected_error_msgs:
-                    assert msg.replace("\n", "") in str(e.value).replace("\n", "")
-            else:
-                result = bcftools_pipe_task(**params)
-                assert result is not None
+            with capture_logs() as cap_logs:
+                if not expect_success:
+                    with pytest.raises((VCFDimensionsEntryMissingError, TaskUserError)) as e:
+                        bcftools_pipe_task(**params)
+                    for msg in expected_error_msgs:
+                        assert msg.replace("\n", "") in str(e.value).replace("\n", "")
+                else:
+                    result = bcftools_pipe_task(**params)
+                    assert result is not None
 
-            for log_msg in expected_logs:
-                assert log_msg in caplog.text
+                for log_msg in expected_logs:
+                    assert _text_in_logs(text=log_msg, logs=cap_logs)
 
-            print(f"Captured logs:\n{caplog.text}")
+            print(f"Captured logs:\n{cap_logs}")
     finally:
         current_app.conf.task_always_eager = original_task_always_eager
         current_app.conf.task_eager_propagates = original_task_eager_propagates

--- a/tests/e2e_integration/queries_integration/test_bcftools_tasks.py
+++ b/tests/e2e_integration/queries_integration/test_bcftools_tasks.py
@@ -474,7 +474,7 @@ def test_bcftools_pipe_cli_integration_with_eager_mode(
                 return self._stdout, self._stderr
 
         container_id = get_container_id("divbase-tests-worker-quick-1")
-        logger = structlog.get_logger()
+        logger = structlog.get_logger(__name__)
         logger.debug(f"Executing command in container with ID: {container_id}")
         docker_cmd = ["docker", "exec", "-w", "/app/tests/fixtures", container_id, "bcftools"] + command.split()
         run_result = subprocess.run(
@@ -499,7 +499,7 @@ def test_bcftools_pipe_cli_integration_with_eager_mode(
             yield self
         finally:
             if self.temp_files:
-                logger = structlog.get_logger()
+                logger = structlog.get_logger(__name__)
                 logger.info(f"Cleaning up {len(self.temp_files)} temporary files")
                 temp_files_with_path = [ensure_fixture_path(f) for f in self.temp_files]
                 self.cleanup_temp_files(temp_files_with_path)
@@ -577,7 +577,7 @@ def test_bcftools_pipe_cli_integration_with_eager_mode(
         Only delete the output file, using the correct path. Don't delete the fixtures, since they should persist.
         """
 
-        logger = structlog.get_logger()
+        logger = structlog.get_logger(__name__)
 
         if output_file is not None:
             output_file = ensure_fixture_path(str(output_file))

--- a/tests/e2e_integration/test_cron_tasks.py
+++ b/tests/e2e_integration/test_cron_tasks.py
@@ -5,11 +5,13 @@ Tests the actual cleanup logic by creating database entries with backdated times
 and verifying that the cleanup tasks correctly delete old entries.
 """
 
+import os
 import random
 import time
 import uuid
 from datetime import datetime, timedelta, timezone
 from enum import StrEnum
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -27,6 +29,7 @@ from divbase_api.worker.cron_tasks import (
     cleanup_old_task_history_task,
     cleanup_soft_deleted_project_versions,
     cleanup_stuck_tasks_task,
+    remove_old_log_files,
     update_storage_usage_metrics,
 )
 
@@ -586,3 +589,55 @@ def test_update_storage_usage_metrics(db_session_sync: Session, CONSTANTS: dict)
             assert project.storage_used_bytes == 0
         if project.name in ["project1", "project2"]:
             assert project.storage_used_bytes > 0
+
+
+def test_remove_old_log_files_deletes_only_expired_log_files(tmp_path: Path):
+    """
+    Test that only log files older than retention period are deleted.
+
+    os.utime used to set the last modified time of the files to simulate old and recently modified files.
+    """
+    retention_days = 30
+    now = datetime.now(timezone.utc)
+
+    old_log_files = ["divbase_api-old.log", "divbase_api-old.log.1", "divbase_api-old.log.2"]
+    for i, log_file in enumerate(old_log_files):
+        file_path = tmp_path / log_file
+        file_path.write_text(f"old log {i}")
+        old_timestamp = (now - timedelta(days=retention_days + 5 + i)).timestamp()
+        os.utime(path=file_path, times=(old_timestamp, old_timestamp))
+
+    recent_logs_files = ["divbase_api-recent.log", "divbase_api-recent.log.1", "divbase_api-recent.log.2"]
+    for i, log_file in enumerate(recent_logs_files):
+        file_path = tmp_path / log_file
+        file_path.write_text(f"recent log {i}")
+        recent_timestamp = (now - timedelta(days=retention_days - 5 - i)).timestamp()
+        os.utime(path=file_path, times=(recent_timestamp, recent_timestamp))
+
+    not_a_log_file = tmp_path / "notes.txt"
+    not_a_log_file.write_text("should be ignored even if old")
+    ignored_timestamp = (now - timedelta(days=retention_days + 10)).timestamp()
+    os.utime(path=not_a_log_file, times=(ignored_timestamp, ignored_timestamp))
+
+    with patch("divbase_api.worker.cron_tasks.LOG_FILES_DIR", tmp_path):
+        result = remove_old_log_files(log_retention_days=retention_days)
+
+    assert result["status"] == "completed"
+    assert result["number_of_log_files_deleted"] == 3
+    assert result["retention_days"] == retention_days
+    for log_file in old_log_files:
+        assert not (tmp_path / log_file).exists(), f"{log_file} should have been deleted"
+    for log_file in recent_logs_files:
+        assert (tmp_path / log_file).exists(), f"{log_file} should not have been deleted"
+    assert (tmp_path / not_a_log_file).exists()
+
+
+def test_remove_old_log_files_handles_missing_directory():
+    """Test that if no logs dir exists (because writing to logs is optional), then exits gracefully without error."""
+    missing_dir = Path("does-not-exist")
+
+    with patch("divbase_api.worker.cron_tasks.LOG_FILES_DIR", missing_dir):
+        result = remove_old_log_files()
+
+    assert result["status"] == "completed"
+    assert result["number_of_log_files_deleted"] == "N/A - log directory does not exist"

--- a/tests/unit/divbase_api/services/test_SidecarQueryManager.py
+++ b/tests/unit/divbase_api/services/test_SidecarQueryManager.py
@@ -1,12 +1,13 @@
-import logging
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from structlog.testing import capture_logs
 
 from divbase_api.services.metadata_queries import SidecarQueryManager
 from divbase_lib.exceptions import SidecarColumnNotFoundError, SidecarInvalidFilterError, SidecarNoDataLoadedError
+from tests.conftest import _text_in_logs
 
 
 @pytest.mark.unit
@@ -53,15 +54,17 @@ def test_run_query_invalid_filter_raises_custom_exception(create_sidecar_manager
 
 
 @pytest.mark.unit
-def test_empty_string(valid_tsv_path, caplog):
+def test_empty_string(valid_tsv_path):
     """
     Test that an empty input filter returns all records and that unique values are extracted correctly.
     """
     manager = SidecarQueryManager(valid_tsv_path)
-    with caplog.at_level("WARNING"):
+    with capture_logs() as cap_logs:
         manager.run_query("")
 
-    assert "Empty filter provided - returning ALL records. This may be a large result set." in caplog.text
+    assert _text_in_logs(
+        text="Empty filter provided - returning ALL records. This may be a large result set.", logs=cap_logs
+    )
     assert sorted(manager.get_unique_values("col1")) == ["A", "B"]
     assert sorted(manager.get_unique_values("col2")) == [1, 2, 3]
 
@@ -112,16 +115,16 @@ def test_sidecar_query_manager_chain(sample_tsv_file):
 
 
 @pytest.mark.unit
-def test_tsv_query_empty_filter(sample_tsv_file, caplog, create_sidecar_manager):
+def test_tsv_query_empty_filter(sample_tsv_file, create_sidecar_manager):
     """Test that empty filter returns all records with a warning."""
-    with caplog.at_level(logging.WARNING):
+    with capture_logs() as cap_logs:
         manager = create_sidecar_manager(sample_tsv_file)
         manager.run_query(filter_string="")
         query_result = manager.query_result
         query_message = manager.query_message
 
     assert len(query_result) == 5, "Empty filter should return all records"
-    assert "Empty filter provided - returning ALL records" in caplog.text
+    assert _text_in_logs(text="Empty filter provided - returning ALL records", logs=cap_logs)
     assert "ALL RECORDS" in query_message
 
 
@@ -136,37 +139,38 @@ def test_tsv_query_none_filter(sample_tsv_file, create_sidecar_manager):
 
 
 @pytest.mark.unit
-def test_tsv_query_column_not_found(sample_tsv_file, caplog, create_sidecar_manager):
+def test_tsv_query_column_not_found(sample_tsv_file, create_sidecar_manager):
     """Test that a non-existent column raises SidecarInvalidFilterError."""
-    with caplog.at_level(logging.WARNING):
+    with capture_logs() as cap_logs:
         manager = create_sidecar_manager(sample_tsv_file)
         with pytest.raises(SidecarInvalidFilterError) as exc_info:
             manager.run_query(filter_string="NonExistentColumn:Value")
 
-    assert "Column 'NonExistentColumn' not found in the TSV file" in caplog.text
+    assert _text_in_logs(text="Column 'NonExistentColumn' not found in the TSV file", logs=cap_logs)
     assert "NonExistentColumn:Value" in str(exc_info.value)
 
 
 @pytest.mark.unit
-def test_tsv_query_value_not_found(sample_tsv_file, caplog, create_sidecar_manager):
+def test_tsv_query_value_not_found(sample_tsv_file, create_sidecar_manager):
     """Test handling of filter with non-existent values."""
-    with caplog.at_level(logging.WARNING):
+    with capture_logs() as cap_logs:
         manager = create_sidecar_manager(sample_tsv_file)
         manager.run_query(filter_string="Population:NonExistentPop")
         query_result = manager.query_result
 
     assert len(query_result) == 0, "Should return empty DataFrame when no values match"
-    assert "No results for the filter ['NonExistentPop'] were found in column 'Population'" in caplog.text
+    assert _text_in_logs(
+        text="No results for the filter ['NonExistentPop'] were found in column 'Population'", logs=cap_logs
+    )
 
 
 @pytest.mark.unit
-def test_tsv_query_invalid_filter_format(sample_tsv_file, caplog, create_sidecar_manager):
+def test_tsv_query_invalid_filter_format(sample_tsv_file, create_sidecar_manager):
     """Test handling of incorrectly formatted filter."""
-    with caplog.at_level(logging.WARNING):
-        manager = create_sidecar_manager(sample_tsv_file)
-        with pytest.raises(SidecarInvalidFilterError) as exc_info:
-            manager.run_query(filter_string="InvalidFormatNoColon")
-        assert "Invalid filter format" in str(exc_info.value)
+    manager = create_sidecar_manager(sample_tsv_file)
+    with pytest.raises(SidecarInvalidFilterError) as exc_info:
+        manager.run_query(filter_string="InvalidFormatNoColon")
+    assert "Invalid filter format" in str(exc_info.value)
 
 
 @pytest.mark.unit

--- a/tests/unit/divbase_api/test_vcf_query_task.py
+++ b/tests/unit/divbase_api/test_vcf_query_task.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from structlog.testing import capture_logs
 
 import divbase_api.services.vcf_queries as queries_module
 from divbase_api.services.vcf_queries import (
@@ -24,7 +25,7 @@ from divbase_api.worker.tasks import (
     _resolve_inputs_for_cli_samples_mode,
 )
 from divbase_lib.exceptions import BcftoolsCommandError, TaskUserError
-from tests.conftest import REGRESSION_GUARD_PREFIX
+from tests.conftest import REGRESSION_GUARD_PREFIX, _text_in_logs
 
 
 class TestDetermineSampleSelectionMode:
@@ -705,6 +706,6 @@ class TestSampleSetOverlapHelpers:
                 _check_if_samples_can_be_combined_with_bcftools(files_to_download, vcf_dimensions_data)
             assert expected_message_part in str(excinfo.value)
         else:
-            with caplog.at_level("INFO"):
+            with capture_logs() as cap_logs:
                 _check_if_samples_can_be_combined_with_bcftools(files_to_download, vcf_dimensions_data)
-            assert expected_message_part in caplog.text
+            assert _text_in_logs(text=expected_message_part, logs=cap_logs)

--- a/uv.lock
+++ b/uv.lock
@@ -741,6 +741,7 @@ dependencies = [
     { name = "pyjwt" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "starlette-admin" },
+    { name = "structlog" },
     { name = "uvicorn" },
 ]
 
@@ -761,6 +762,7 @@ requires-dist = [
     { name = "pyjwt", specifier = "==2.12.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = "==2.0.47" },
     { name = "starlette-admin", specifier = "==0.16.0" },
+    { name = "structlog", specifier = ">=25.5.0" },
     { name = "uvicorn", specifier = "==0.41.0" },
 ]
 
@@ -2800,6 +2802,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/34/0e/2408735aca9e764643196212f9069912100151414dd617d39ffc72d77eee/statsmodels-0.14.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3414e40c073d725007a6603a18247ab7af3467e1af4a5e5a24e4c27bc26673b4", size = 10337587, upload-time = "2025-12-05T23:13:37.597Z" },
     { url = "https://files.pythonhosted.org/packages/0f/36/4d44f7035ab3c0b2b6a4c4ebb98dedf36246ccbc1b3e2f51ebcd7ac83abb/statsmodels-0.14.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a518d3f9889ef920116f9fa56d0338069e110f823926356946dae83bc9e33e19", size = 10363350, upload-time = "2025-12-05T23:13:53.08Z" },
     { url = "https://files.pythonhosted.org/packages/26/33/f1652d0c59fa51de18492ee2345b65372550501ad061daa38f950be390b6/statsmodels-0.14.6-cp314-cp314-win_amd64.whl", hash = "sha256:151b73e29f01fe619dbce7f66d61a356e9d1fe5e906529b78807df9189c37721", size = 9588010, upload-time = "2025-12-05T23:14:07.28Z" },
+]
+
+[[package]]
+name = "structlog"
+version = "25.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> [!NOTE]
> Quick note on number of files changed: This PR looks more scary than it is, as a lot of the files changed here are simply replacing:

```bash
# this 
logger = logging.getLogger(__name__)
import logging
# with this
import structlog
logger = structlog.get_logger(__name__)
```


### Summary of changes

In this PR I've introduced structlog for the API and worker, which is the first part giving us a good logging setup in deployed environments - next block of work is in the argocd repo. 
- Now, with each log request sent to the API, a "request id" (uuid4) is attached/bound to the logger, so it is easier to trace all logs messages. This is also returned to the user as a header in the response and is displayed to the user in the case of CLI error messages, (so we can trace the error more easily from a user bug report). 
- Likewise, the task id is attached/bound to the logger for each celery task for similar benefits. 
- Added a small dev docs on logging.
- Updates tests that were looking at log messages accordingly and added some e2e tests for api middleware behavior. 


### Some useful links:
- What should the application do vs what should the monitoring system do: https://12factor.net/logs  
- https://www.structlog.org/en/stable/frameworks.html (where I got celery implementation from)
- https://wazaari.dev/blog/fastapi-structlog-integration (adapted for fastapi logging setup). 

### Plan:
- Review from the robot. 
- Make a new deployment on the dev cluster with these changes and setup that side of things. Edit anything needed over here as appropriate.
- Open to review once happy over there. 

### R.E. query vcf logs 
I am happy to look into outputting task query logs for users, but will save it for a separate PR as a follow on. 