### PR TITLE
SQ915: User log file for query vcf tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ __pycache__/
 tests/fixtures/temp*
 tests/fixtures/merged*
 divbase_metadata_template*.tsv
+# query results files
+result_of_job_*.vcf.gz
+result_of_job_*.log
 
 # query job config files
 bcftools_divbase_job_config.json

--- a/packages/divbase-api/src/divbase_api/logging_config.py
+++ b/packages/divbase-api/src/divbase_api/logging_config.py
@@ -16,10 +16,25 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 import structlog
+from structlog.types import EventDict
 
 from divbase_lib.divbase_constants import LOCAL_DEV_ENVIRONMENTS
 
 LOG_FILES_DIR = Path("/logs")
+
+# shared for both (1) application logs and (2) task logs given to users
+_SHARED_PROCESSORS: list[structlog.types.Processor] = [
+    structlog.contextvars.merge_contextvars,
+    structlog.stdlib.add_log_level,
+    structlog.stdlib.add_logger_name,
+    structlog.stdlib.PositionalArgumentsFormatter(),
+    structlog.processors.StackInfoRenderer(),
+]
+
+_APP_LOG_PROCESSORS: list[structlog.types.Processor] = [
+    *_SHARED_PROCESSORS,
+    structlog.processors.TimeStamper(fmt="iso"),
+]
 
 
 class SkipHealthyApiChecksFilter(logging.Filter):
@@ -58,18 +73,9 @@ def configure_logging(log_level: str, environment: str, service_name: str, log_t
 
     level = getattr(logging, log_level.upper())
 
-    shared_processors: list[structlog.types.Processor] = [
-        structlog.contextvars.merge_contextvars,
-        structlog.stdlib.add_logger_name,
-        structlog.stdlib.add_log_level,
-        structlog.stdlib.PositionalArgumentsFormatter(),
-        structlog.processors.TimeStamper(fmt="iso"),
-        structlog.processors.StackInfoRenderer(),
-    ]
-
     structlog.configure(
         processors=[
-            *shared_processors,
+            *_APP_LOG_PROCESSORS,
             structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
         ],
         wrapper_class=structlog.make_filtering_bound_logger(level),
@@ -80,7 +86,7 @@ def configure_logging(log_level: str, environment: str, service_name: str, log_t
 
     # handles non structlog logs
     formatter = structlog.stdlib.ProcessorFormatter(
-        foreign_pre_chain=shared_processors,
+        foreign_pre_chain=_APP_LOG_PROCESSORS,
         processors=[
             structlog.stdlib.ProcessorFormatter.remove_processors_meta,
             renderer,
@@ -117,3 +123,38 @@ def configure_logging(log_level: str, environment: str, service_name: str, log_t
         uvicorn_logger = logging.getLogger(name)
         uvicorn_logger.handlers.clear()
         uvicorn_logger.propagate = True
+
+
+def create_task_log_handler(log_file: Path, header: str) -> logging.Handler:
+    """
+    Create a log handler for a user log file for a Celery task.
+    We append a header to the log file with task info and return a FileHandler that will write human readable logs.
+    """
+    log_file.unlink(missing_ok=True)  # ensure we have a fresh log file for each job
+    log_file.parent.mkdir(exist_ok=True, parents=True)
+    log_file.write_text(header, encoding="utf-8")
+
+    formatter = structlog.stdlib.ProcessorFormatter(
+        foreign_pre_chain=_SHARED_PROCESSORS,
+        processors=[
+            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+            _simplify_user_log_events,
+            structlog.dev.ConsoleRenderer(colors=False, exception_formatter=structlog.dev.plain_traceback),
+        ],
+    )
+    handler = logging.FileHandler(log_file, mode="a", encoding="utf-8")
+    handler.setFormatter(formatter)
+    return handler
+
+
+def _simplify_user_log_events(_logger, _method, event_dict: EventDict) -> EventDict:
+    """
+    Remove what would be a lot of noise from user-facing task log files.
+    It's same task_id + name throughout a user's log file and timestarted is shown in the log header.
+    'logger' is the modules name, decided to also remove that for simplicity
+    """
+    event_dict.pop("timestamp", None)
+    event_dict.pop("task_id", None)
+    event_dict.pop("task_name", None)
+    event_dict.pop("logger", None)
+    return event_dict

--- a/packages/divbase-api/src/divbase_api/logging_config.py
+++ b/packages/divbase-api/src/divbase_api/logging_config.py
@@ -125,24 +125,24 @@ def configure_logging(log_level: str, environment: str, service_name: str, log_t
         uvicorn_logger.propagate = True
 
 
-def create_task_log_handler(log_file: Path, header: str) -> logging.Handler:
+def create_user_task_log_handler(log_file: Path) -> logging.Handler:
     """
-    Create a log handler for a user log file for a Celery task.
-    We append a header to the log file with task info and return a FileHandler that will write human readable logs.
+    Create an empty log file for user query logs and return a FileHandler that can writes human-readable log lines to it.
+    Note that as these are for user facing logs we:
+        1. drop stacktraces (they could leak something sensitive) and
+        2. simplify log lines by removing some fields like date, module used etc...
     """
-    log_file.unlink(missing_ok=True)  # ensure we have a fresh log file for each job
     log_file.parent.mkdir(exist_ok=True, parents=True)
-    log_file.write_text(header, encoding="utf-8")
-
     formatter = structlog.stdlib.ProcessorFormatter(
         foreign_pre_chain=_SHARED_PROCESSORS,
         processors=[
             structlog.stdlib.ProcessorFormatter.remove_processors_meta,
             _simplify_user_log_events,
-            structlog.dev.ConsoleRenderer(colors=False, exception_formatter=structlog.dev.plain_traceback),
+            _strip_exc_info,
+            structlog.dev.ConsoleRenderer(colors=False),
         ],
     )
-    handler = logging.FileHandler(log_file, mode="a", encoding="utf-8")
+    handler = logging.FileHandler(log_file, mode="w", encoding="utf-8")
     handler.setFormatter(formatter)
     return handler
 
@@ -157,4 +157,11 @@ def _simplify_user_log_events(_logger, _method, event_dict: EventDict) -> EventD
     event_dict.pop("task_id", None)
     event_dict.pop("task_name", None)
     event_dict.pop("logger", None)
+    return event_dict
+
+
+def _strip_exc_info(_logger, _method, event_dict: EventDict) -> EventDict:
+    """Strip traceback info from user-facing log lines — show the error message only."""
+    event_dict.pop("exc_info", None)
+    event_dict.pop("exception", None)
     return event_dict

--- a/packages/divbase-api/src/divbase_api/scripts/cleanup_expired_files.py
+++ b/packages/divbase-api/src/divbase_api/scripts/cleanup_expired_files.py
@@ -182,7 +182,7 @@ def delete_expired_results_files(
     s3_file_manager: S3FileManager, buckets: list[str], results_files_retention_days: int
 ) -> tuple[int, int, bool]:
     """
-    Results files (and there associated log files) older than cutoff date are considered expired and are hard deleted.
+    Results files (and their associated log files) older than cutoff date are considered expired and are hard deleted.
 
     We also cover any delete markers that may have been placed on the results files, to ensure they are also fully purged.
 

--- a/packages/divbase-api/src/divbase_api/scripts/cleanup_expired_files.py
+++ b/packages/divbase-api/src/divbase_api/scripts/cleanup_expired_files.py
@@ -182,7 +182,7 @@ def delete_expired_results_files(
     s3_file_manager: S3FileManager, buckets: list[str], results_files_retention_days: int
 ) -> tuple[int, int, bool]:
     """
-    Results files older than cutoff date are considered expired and are hard deleted.
+    Results files (and there associated log files) older than cutoff date are considered expired and are hard deleted.
 
     We also cover any delete markers that may have been placed on the results files, to ensure they are also fully purged.
 

--- a/packages/divbase-api/src/divbase_api/services/vcf_queries.py
+++ b/packages/divbase-api/src/divbase_api/services/vcf_queries.py
@@ -26,7 +26,7 @@ from divbase_lib.exceptions import (
     BcftoolsPipeUnsupportedCommandError,
     TaskUserError,
 )
-from divbase_lib.utils import split_semicolon_bcftools_command_segments
+from divbase_lib.utils import format_file_size, split_semicolon_bcftools_command_segments
 
 logger = structlog.get_logger(__name__)
 
@@ -1000,7 +1000,7 @@ class BcftoolsQueryManager:
         sort_command = f"sort -Oz -o {output_file} {annotated_unsorted_output_file}"
         proc = run_bcftools(command=sort_command, capture_stderr=True)
         self._wait_proc_and_check_return_code(proc=proc, command=sort_command)
-        self._log_file_size(output_file)
+        self._log_file_size(str(output_file))
         logger.info(
             f"Sorting the results file to ensure proper order of variants. Final results are in '{output_file}'."
         )
@@ -1090,15 +1090,13 @@ class BcftoolsQueryManager:
 
     def _log_file_size(self, file_path: str):
         """
-        Log the size of the a given file in both GB and GiB.
-        """
-
+        Log the size of the a given file in a human-readable format.
         # TODO consider changing to logger debug later in the dev process
+        """
         try:
             size_bytes = os.path.getsize(file_path)
-            size_gb = size_bytes / (1000 * 1000 * 1000)
-            size_gi = size_bytes / (1024 * 1024 * 1024)
-            logger.info(f"File '{file_path}' size: {size_gb:.2f} GB, {size_gi:.2f} Gi")
+            formatted_size = format_file_size(size_bytes)
+            logger.info(f"File '{file_path}' size: {formatted_size}")
         except Exception as e:
             logger.warning(f"Could not determine size of file '{file_path}': {e}")
 

--- a/packages/divbase-api/src/divbase_api/services/vcf_queries.py
+++ b/packages/divbase-api/src/divbase_api/services/vcf_queries.py
@@ -1090,7 +1090,7 @@ class BcftoolsQueryManager:
 
     def _log_file_size(self, file_path: str):
         """
-        Log the size of the a given file in a human-readable format.
+        Log the size of a given file in a human-readable format.
         # TODO consider changing to logger debug later in the dev process
         """
         try:

--- a/packages/divbase-api/src/divbase_api/worker/tasks.py
+++ b/packages/divbase-api/src/divbase_api/worker/tasks.py
@@ -967,39 +967,34 @@ def _delete_job_files_from_worker(
     vcf_paths: list[Path] | None = None,
     metadata_path: Path | None = None,
     output_file: Path | None = None,
+    log_file: Path | None = None,
 ) -> None:
     """
     After uploading results to bucket, delete job files from the worker.
+    TODO - it would be better to just have a dir per job (e.g. /<task_id>/) and rm the dir after each job,
+    to ensure isolation even in job failure.
+    but that requires more refactorign and care.
     """
-
     vcf_paths = vcf_paths or []
     for vcf_path in vcf_paths:
-        try:
-            os.remove(vcf_path)
-            logger.info(f"Deleted {vcf_path} from worker.")
-        except Exception as e:
-            logger.warning(f"Could not delete input VCF file from worker {vcf_path}: {e}")
+        vcf_path.unlink(missing_ok=True)
+        logger.info(f"Deleted {vcf_path} from worker.")
+
         csi_path = vcf_path.with_suffix(vcf_path.suffix + ".csi")
-        if csi_path.exists():
-            try:
-                os.remove(csi_path)
-                logger.info(f"Deleted CSI index {csi_path} from worker.")
-            except Exception as e:
-                logger.warning(f"Could not delete CSI index file {csi_path}: {e}")
+        csi_path.unlink(missing_ok=True)
+        logger.info(f"Deleted CSI index {csi_path} from worker.")
 
-    if metadata_path is not None:
-        try:
-            os.remove(metadata_path)
-            logger.info(f"Deleted {metadata_path} from worker.")
-        except Exception as e:
-            logger.warning(f"Could not delete metadata file from worker {metadata_path}: {e}")
+    if metadata_path:
+        metadata_path.unlink(missing_ok=True)
+        logger.info(f"Deleted {metadata_path} from worker.")
 
-    if output_file is not None:
-        try:
-            os.remove(output_file)
-            logger.info(f"Deleted {output_file} from worker.")
-        except Exception as e:
-            logger.warning(f"Could not delete output file from worker {output_file}: {e}")
+    if output_file:
+        output_file.unlink(missing_ok=True)
+        logger.info(f"Deleted {output_file} from worker.")
+
+    if log_file:
+        log_file.unlink(missing_ok=True)
+        logger.info(f"Deleted {log_file} from worker.")
 
 
 def _check_if_samples_can_be_combined_with_bcftools(

--- a/packages/divbase-api/src/divbase_api/worker/tasks.py
+++ b/packages/divbase-api/src/divbase_api/worker/tasks.py
@@ -1,5 +1,4 @@
 import dataclasses
-import os
 import time
 from datetime import datetime, timezone
 from enum import Enum
@@ -270,53 +269,52 @@ def sample_metadata_query_task(
     user_id: int,
 ) -> dict:
     """Run a sample metadata query task as a Celery task."""
-    task_id = sample_metadata_query_task.request.id
-    s3_file_manager = _create_s3_file_manager()
-
-    metadata_path = _download_sample_metadata_for_task(
-        metadata_tsv_name=metadata_tsv_name,
-        bucket_name=bucket_name,
-        s3_file_manager=s3_file_manager,
-        project_name=project_name,
-    )
-
-    with SyncSessionLocal() as db:
-        vcf_dimensions_data = get_vcf_metadata_by_project(project_id=project_id, db=db)
-
-    if not vcf_dimensions_data.vcf_files:
-        # Wrap exeception in TaskUserError () to avoid Celery serilization UnpicklableExceptionWrapper issue
-        raise TaskUserError(str(VCFDimensionsEntryMissingError(project_name=project_name))) from None
-
-    latest_versions_of_bucket_files = s3_file_manager.latest_version_of_all_files(bucket_name=bucket_name)
-
-    _check_that_dimensions_is_up_to_date_with_VCF_files_in_bucket(
-        vcf_dimensions_data=vcf_dimensions_data,
-        latest_versions_of_bucket_files=latest_versions_of_bucket_files,
-        project_id=project_id,
-    )
-
-    metadata_result = run_sidecar_metadata_query(
-        file=metadata_path,
-        filter_string=tsv_filter,
-        project_id=project_id,
-        vcf_dimensions_data=vcf_dimensions_data,
-    )
-
     try:
-        os.remove(metadata_path)
-        logger.info(f"Deleted metadata file {metadata_path} from worker.")
-    except Exception as e:
-        logger.warning(f"Could not delete metadata file {metadata_path}: {e}")
+        task_id = sample_metadata_query_task.request.id
+        s3_file_manager = _create_s3_file_manager()
 
-    # Convert to dict since celery serializes to JSON when sending back to API layer
-    result = metadata_result.model_dump()
-    result["status"] = "completed"
-    result["task_id"] = task_id
+        metadata_path = _download_sample_metadata_for_task(
+            metadata_tsv_name=metadata_tsv_name,
+            bucket_name=bucket_name,
+            s3_file_manager=s3_file_manager,
+            project_name=project_name,
+        )
 
-    logger.info(
-        f"Metadata query completed: {len(metadata_result.unique_sample_ids)} samples "
-        f"mapped to {len(metadata_result.unique_filenames)} VCF files"
-    )
+        with SyncSessionLocal() as db:
+            vcf_dimensions_data = get_vcf_metadata_by_project(project_id=project_id, db=db)
+
+        if not vcf_dimensions_data.vcf_files:
+            # Wrap exeception in TaskUserError () to avoid Celery serilization UnpicklableExceptionWrapper issue
+            raise TaskUserError(str(VCFDimensionsEntryMissingError(project_name=project_name))) from None
+
+        latest_versions_of_bucket_files = s3_file_manager.latest_version_of_all_files(bucket_name=bucket_name)
+
+        _check_that_dimensions_is_up_to_date_with_VCF_files_in_bucket(
+            vcf_dimensions_data=vcf_dimensions_data,
+            latest_versions_of_bucket_files=latest_versions_of_bucket_files,
+            project_id=project_id,
+        )
+
+        metadata_result = run_sidecar_metadata_query(
+            file=metadata_path,
+            filter_string=tsv_filter,
+            project_id=project_id,
+            vcf_dimensions_data=vcf_dimensions_data,
+        )
+
+        # Convert to dict since celery serializes to JSON when sending back to API layer
+        result = metadata_result.model_dump()
+        result["status"] = "completed"
+        result["task_id"] = task_id
+
+        logger.info(
+            f"Metadata query completed: {len(metadata_result.unique_sample_ids)} samples "
+            f"mapped to {len(metadata_result.unique_filenames)} VCF files"
+        )
+    finally:
+        if metadata_path and metadata_path.exists():
+            metadata_path.unlink(missing_ok=True)
+            logger.info(f"Deleted metadata file {metadata_path} from worker.")
 
     return result
 

--- a/packages/divbase-api/src/divbase_api/worker/tasks.py
+++ b/packages/divbase-api/src/divbase_api/worker/tasks.py
@@ -9,7 +9,6 @@ from datetime import datetime, timezone
 from enum import Enum
 from itertools import combinations
 from pathlib import Path
-from zoneinfo import ZoneInfo
 
 import psutil
 import structlog
@@ -506,14 +505,14 @@ def bcftools_pipe_task(
         divbase_lib_logger.removeHandler(log_handler)
         log_handler.close()
         try:
-            log_date = datetime.now(tz=ZoneInfo("Europe/Stockholm")).strftime("%Y-%m-%d %H:%M:%S %Z")
+            log_date = datetime.now().strftime("%Y-%m-%d")
             header = (
                 "DivBase query vcf task log\n"
                 "=================\n"
                 f"Job Status: {'SUCCESS' if task_succeeded else 'FAILURE'}\n"
                 f"DivBase version: {divbase_version}\n"
                 f"BCFtools version: {_get_bcftools_version()}\n"
-                f"Task Started At: {log_date}\n"
+                f"Date: {log_date}\n"
                 f"Project: {project_name}\n"
                 f"Sample Selection Mode: {_build_sample_selection_replacement(sample_selection_mode, tsv_filter, samples)}\n"
                 f"User inputted bcftools command used: '{command}'\n"
@@ -807,7 +806,7 @@ def _upload_log_file(log_file: Path, header: str, bucket_name: str, s3_file_mana
     Unlike a results file upload, a failed log file upload should not cause the task to be marked as failed.
     """
     # in the event the log file is very large, this is to avoid reading the whole at once.
-    with tempfile.NamedTemporaryFile(mode="w", delete=False, encoding="utf-8") as tmp:
+    with tempfile.NamedTemporaryFile(mode="w", dir=log_file.parent, delete=False, encoding="utf-8") as tmp:
         tmp.write(header)
         with open(log_file, encoding="utf-8") as body:
             shutil.copyfileobj(body, tmp)

--- a/packages/divbase-api/src/divbase_api/worker/tasks.py
+++ b/packages/divbase-api/src/divbase_api/worker/tasks.py
@@ -1,7 +1,9 @@
 import dataclasses
 import functools
 import logging
+import shutil
 import subprocess
+import tempfile
 import time
 from datetime import datetime, timezone
 from enum import Enum
@@ -11,7 +13,6 @@ from zoneinfo import ZoneInfo
 
 import psutil
 import structlog
-from botocore.exceptions import BotoCoreError
 from celery import Celery
 from celery.signals import (
     after_task_publish,
@@ -31,7 +32,7 @@ from divbase_api.exceptions import (
     TSVFileNotFoundInProjectError,
     VCFDimensionsEntryMissingError,
 )
-from divbase_api.logging_config import configure_logging, create_task_log_handler
+from divbase_api.logging_config import configure_logging, create_user_task_log_handler
 from divbase_api.models.task_history import TaskHistoryDB, TaskStartedAtDB
 from divbase_api.services.metadata_queries import run_sidecar_metadata_query
 from divbase_api.services.s3_client import S3FileManager
@@ -355,25 +356,11 @@ def bcftools_pipe_task(
     s3_file_manager = _create_s3_file_manager()
 
     log_file = Path(f"{QUERY_RESULTS_FILE_PREFIX}{job_id}.log")
-    log_date = datetime.now(tz=ZoneInfo("Europe/Stockholm")).strftime("%Y-%m-%d %H:%M:%S %Z")
-    header = (
-        "DivBase query vcf task log\n"
-        "=================\n"
-        "Job Status: JOB_STATUS_PLACEHOLDER\n"  # will get replaced at the end of the task
-        f"DivBase version: {divbase_version}\n"
-        f"BCFtools version: {_get_bcftools_version()}\n"
-        f"Date: {log_date}\n"
-        f"Project: {project_name}\n"
-        f"Sample Selection Mode: SAMPLE_FILTER_PLACEHOLDER\n"  # TODO placeholder update on _determine_sample_selection_mode
-        # if e.g. tsv_filter, include the filter in 2nd line, same for samples
-        f"User inputted bcftools command used: '{command}'\n"
-        f"Task ID: {job_id}\n"
-        f"DivBase internal task ID: {task_id}\n"
-        "=================\n\n"
-    )
-    log_handler = create_task_log_handler(log_file=log_file, header=header)
-    root_logger = logging.getLogger()
-    root_logger.addHandler(log_handler)
+    log_handler = create_user_task_log_handler(log_file=log_file)
+    divbase_api_logger = logging.getLogger("divbase_api")
+    divbase_lib_logger = logging.getLogger("divbase_lib")
+    divbase_api_logger.addHandler(log_handler)
+    divbase_lib_logger.addHandler(log_handler)
 
     # assigned here so even if early exit from error the finally block will be able to clean them up.
     vcf_paths: list[Path] = []
@@ -502,32 +489,41 @@ def bcftools_pipe_task(
         bcftools_mem_peak = bcftools_metrics.get("peak_memory_bytes", 0)
         bcftools_mem_avg = bcftools_metrics.get("avg_memory_bytes", 0)
         bcftools_walltime = bcftools_metrics.get("walltime_seconds", 0.0)
-
         _upload_results_file(output_file=output_file, bucket_name=bucket_name, s3_file_manager=s3_file_manager)
         task_succeeded = True
 
     except Exception as e:
-        # This ensures the user gets any error message in their log file
-        logger.exception(f"An error occurred running your task: {str(e)}", exc_info=True)
+        # This ensures the user gets any error message from the run in their log file
+        # We do not include the stacktrace since it could contain sensitive info.
+        logger.error(
+            f"An error of type: '{type(e).__name__}' occurred running your task, error message was:\n {e}",
+            exc_info=False,
+        )
         raise
 
     finally:
-        root_logger.removeHandler(log_handler)
+        divbase_api_logger.removeHandler(log_handler)
+        divbase_lib_logger.removeHandler(log_handler)
         log_handler.close()
-        job_status_text = "SUCCESS" if task_succeeded else "FAILURE"
-        sample_filter_text = _build_sample_selection_replacement(
-            sample_selection_mode=sample_selection_mode,
-            tsv_filter=tsv_filter,
-            samples=samples,
-        )
-        _update_log_header(
-            log_file,
-            replacements={
-                "JOB_STATUS_PLACEHOLDER": job_status_text,
-                "SAMPLE_FILTER_PLACEHOLDER": sample_filter_text,
-            },
-        )
-        _upload_log_file(log_file=log_file, bucket_name=bucket_name, s3_file_manager=s3_file_manager)
+        try:
+            log_date = datetime.now(tz=ZoneInfo("Europe/Stockholm")).strftime("%Y-%m-%d %H:%M:%S %Z")
+            header = (
+                "DivBase query vcf task log\n"
+                "=================\n"
+                f"Job Status: {'SUCCESS' if task_succeeded else 'FAILURE'}\n"
+                f"DivBase version: {divbase_version}\n"
+                f"BCFtools version: {_get_bcftools_version()}\n"
+                f"Task Started At: {log_date}\n"
+                f"Project: {project_name}\n"
+                f"Sample Selection Mode: {_build_sample_selection_replacement(sample_selection_mode, tsv_filter, samples)}\n"
+                f"User inputted bcftools command used: '{command}'\n"
+                f"Task ID: {job_id}\n"
+                f"DivBase internal task ID: {task_id}\n"
+                "=================\n\n"
+            )
+            _upload_log_file(log_file=log_file, header=header, bucket_name=bucket_name, s3_file_manager=s3_file_manager)
+        except Exception as e:
+            logger.error(f"Failed to upload user log file for job {job_id} to S3: {str(e)}", exc_info=True)
         _delete_job_files_from_worker(
             vcf_paths=vcf_paths,
             metadata_path=metadata_path,
@@ -805,26 +801,22 @@ def _upload_results_file(output_file: Path, bucket_name: str, s3_file_manager: S
     )
 
 
-def _upload_log_file(log_file: Path, bucket_name: str, s3_file_manager: S3FileManager) -> None:
+def _upload_log_file(log_file: Path, header: str, bucket_name: str, s3_file_manager: S3FileManager) -> None:
     """
-    Upload the per-job log file to S3.
+    Append the log header and upload the users log file to s3.
     Unlike a results file upload, a failed log file upload should not cause the task to be marked as failed.
     """
-    try:
-        _ = s3_file_manager.upload_files(
-            to_upload={log_file.name: log_file},
-            bucket_name=bucket_name,
-        )
-    except (BotoCoreError, FileNotFoundError) as e:
-        logger.exception(f"Could not upload log file {log_file.name} to S3: {e}")
-
-
-def _update_log_header(log_file: Path, replacements: dict[str, str]) -> None:
-    """find and replace all placeholder in the user log file header."""
-    content = log_file.read_text(encoding="utf-8")
-    for old, new in replacements.items():
-        content = content.replace(old, new, count=1)
-    log_file.write_text(content, encoding="utf-8")
+    # in the event the log file is very large, this is to avoid reading the whole at once.
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, encoding="utf-8") as tmp:
+        tmp.write(header)
+        with open(log_file, encoding="utf-8") as body:
+            shutil.copyfileobj(body, tmp)
+    tmp_path = Path(tmp.name)
+    tmp_path.replace(log_file)
+    _ = s3_file_manager.upload_files(
+        to_upload={log_file.name: log_file},
+        bucket_name=bucket_name,
+    )
 
 
 def _build_sample_selection_replacement(
@@ -1082,7 +1074,7 @@ def _delete_job_files_from_worker(
     After uploading results to bucket, delete job files from the worker.
     TODO - it would be better to just have a dir per job (e.g. /<task_id>/) and rm the dir after each job,
     to ensure isolation even in job failure.
-    but that requires more refactorign and care.
+    but that requires more refactoring and care.
     """
     vcf_paths = vcf_paths or []
     for vcf_path in vcf_paths:

--- a/packages/divbase-api/src/divbase_api/worker/tasks.py
+++ b/packages/divbase-api/src/divbase_api/worker/tasks.py
@@ -1,12 +1,16 @@
 import dataclasses
+import logging
+import subprocess
 import time
 from datetime import datetime, timezone
 from enum import Enum
 from itertools import combinations
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 import psutil
 import structlog
+from botocore.exceptions import ClientError
 from celery import Celery
 from celery.signals import (
     after_task_publish,
@@ -19,13 +23,14 @@ from celery.signals import (
 )
 from sqlalchemy.exc import SQLAlchemyError
 
+from divbase_api import __version__ as divbase_version
 from divbase_api.crud.s3 import validate_s3_service_account
 from divbase_api.exceptions import (
     ObjectDoesNotExistError,
     TSVFileNotFoundInProjectError,
     VCFDimensionsEntryMissingError,
 )
-from divbase_api.logging_config import configure_logging
+from divbase_api.logging_config import configure_logging, create_task_log_handler
 from divbase_api.models.task_history import TaskHistoryDB, TaskStartedAtDB
 from divbase_api.services.metadata_queries import run_sidecar_metadata_query
 from divbase_api.services.s3_client import S3FileManager
@@ -346,130 +351,183 @@ def bcftools_pipe_task(
     logger.info(f"Starting bcftools_pipe_task with Celery, task ID: {task_id}, job ID: {job_id}")
     s3_file_manager = _create_s3_file_manager()
 
-    with SyncSessionLocal() as db:
-        vcf_dimensions_data = get_vcf_metadata_by_project(project_id=project_id, db=db)
-
-    if not vcf_dimensions_data.vcf_files:
-        # Wrap exeception in TaskUserError () to avoid Celery serilization UnpicklableExceptionWrapper issue
-        raise TaskUserError(str(VCFDimensionsEntryMissingError(project_name=project_name))) from None
-
-    latest_versions_of_bucket_files = s3_file_manager.latest_version_of_all_files(bucket_name=bucket_name)
-    _check_that_dimensions_is_up_to_date_with_VCF_files_in_bucket(
-        vcf_dimensions_data=vcf_dimensions_data,
-        latest_versions_of_bucket_files=latest_versions_of_bucket_files,
-        project_id=project_id,
+    log_file = Path(f"{QUERY_RESULTS_FILE_PREFIX}{job_id}.log")
+    log_date = datetime.now(tz=ZoneInfo("Europe/Stockholm")).strftime("%Y-%m-%d %H:%M:%S %Z")
+    header = (
+        "DivBase query vcf task log\n"
+        "=================\n"
+        "Job Status: JOB_STATUS_PLACEHOLDER\n"  # will get replaced at the end of the task
+        f"DivBase version: {divbase_version}\n"
+        f"BCFtools version: {_get_bcftools_version()}\n"
+        f"Date: {log_date}\n"
+        f"Project: {project_name}\n"
+        f"Sample Selection Mode: SAMPLE_FILTER_PLACEHOLDER\n"  # TODO placeholder update on _determine_sample_selection_mode
+        # if e.g. tsv_filter, include the filter in 2nd line, same for samples
+        f"User inputted bcftools command used: '{command}'\n"
+        f"Task ID: {job_id}\n"
+        f"DivBase internal task ID: {task_id}\n"
+        "=================\n\n"
     )
+    log_handler = create_task_log_handler(log_file=log_file, header=header)
+    root_logger = logging.getLogger()
+    root_logger.addHandler(log_handler)
 
-    sample_selection_mode = _determine_sample_selection_mode(
-        tsv_filter=tsv_filter,
-        samples=samples,
-        all_samples=all_samples,
-    )
+    # assign here so even if early exit from error the finally block will be able to clean them up.
+    vcf_paths: list[Path] = []
+    metadata_path: Path | None = None
+    output_file: Path | None = None
+    task_succeeded = False
+    try:
+        with SyncSessionLocal() as db:
+            vcf_dimensions_data = get_vcf_metadata_by_project(project_id=project_id, db=db)
 
-    if sample_selection_mode == VCFQuerySampleSelectionMode.SAMPLE_METADATA_QUERY:
-        resolved_sample_mode_results = _resolve_inputs_for_sample_metadata_mode(
-            metadata_tsv_name=metadata_tsv_name,
-            bucket_name=bucket_name,
-            s3_file_manager=s3_file_manager,
-            tsv_filter=tsv_filter,
+        if not vcf_dimensions_data.vcf_files:
+            # Wrap exeception in TaskUserError () to avoid Celery serilization UnpicklableExceptionWrapper issue
+            raise TaskUserError(str(VCFDimensionsEntryMissingError(project_name=project_name))) from None
+
+        latest_versions_of_bucket_files = s3_file_manager.latest_version_of_all_files(bucket_name=bucket_name)
+        _check_that_dimensions_is_up_to_date_with_VCF_files_in_bucket(
+            vcf_dimensions_data=vcf_dimensions_data,
+            latest_versions_of_bucket_files=latest_versions_of_bucket_files,
             project_id=project_id,
-            project_name=project_name,
-            vcf_dimensions_data=vcf_dimensions_data,
         )
-    elif sample_selection_mode == VCFQuerySampleSelectionMode.CLI_SAMPLES:
-        resolved_sample_mode_results = _resolve_inputs_for_cli_samples_mode(
+
+        sample_selection_mode = _determine_sample_selection_mode(
+            tsv_filter=tsv_filter,
             samples=samples,
-            vcf_dimensions_data=vcf_dimensions_data,
-        )
-    elif sample_selection_mode == VCFQuerySampleSelectionMode.ALL_SAMPLES:
-        resolved_sample_mode_results = _resolve_inputs_for_all_samples_mode(
-            vcf_dimensions_data=vcf_dimensions_data,
+            all_samples=all_samples,
         )
 
-    files_to_download = resolved_sample_mode_results.files_to_download
-    sample_and_filename_subset = resolved_sample_mode_results.sample_and_filename_subset
-    metadata_path = resolved_sample_mode_results.metadata_path
+        if sample_selection_mode == VCFQuerySampleSelectionMode.SAMPLE_METADATA_QUERY:
+            resolved_sample_mode_results = _resolve_inputs_for_sample_metadata_mode(
+                metadata_tsv_name=metadata_tsv_name,
+                bucket_name=bucket_name,
+                s3_file_manager=s3_file_manager,
+                tsv_filter=tsv_filter,
+                project_id=project_id,
+                project_name=project_name,
+                vcf_dimensions_data=vcf_dimensions_data,
+            )
+        elif sample_selection_mode == VCFQuerySampleSelectionMode.CLI_SAMPLES:
+            resolved_sample_mode_results = _resolve_inputs_for_cli_samples_mode(
+                samples=samples,
+                vcf_dimensions_data=vcf_dimensions_data,
+            )
+        elif sample_selection_mode == VCFQuerySampleSelectionMode.ALL_SAMPLES:
+            resolved_sample_mode_results = _resolve_inputs_for_all_samples_mode(
+                vcf_dimensions_data=vcf_dimensions_data,
+            )
 
-    # Defensive validation in worker: API route validates before queueing, but task execution can also be invoked directly in tests/internal paths.
-    command = validate_user_submitted_bcftools_command(command=command, all_samples=all_samples)
+        files_to_download = resolved_sample_mode_results.files_to_download
+        sample_and_filename_subset = resolved_sample_mode_results.sample_and_filename_subset
+        metadata_path = resolved_sample_mode_results.metadata_path
 
-    region_scaffolds = extract_region_scaffolds_from_command(command=command)
-    if region_scaffolds:
-        files_to_download = _check_for_unnecessary_files_for_region_query(
-            scaffolds=region_scaffolds,
+        # Defensive validation in worker: API route validates before queueing, but task execution can also be invoked directly in tests/internal paths.
+        command = validate_user_submitted_bcftools_command(command=command, all_samples=all_samples)
+
+        region_scaffolds = extract_region_scaffolds_from_command(command=command)
+        if region_scaffolds:
+            files_to_download = _check_for_unnecessary_files_for_region_query(
+                scaffolds=region_scaffolds,
+                files_to_download=files_to_download,
+                vcf_dimensions_data=vcf_dimensions_data,
+            )
+            sample_and_filename_subset = [
+                entry for entry in sample_and_filename_subset if entry.filename in files_to_download
+            ]
+
+        _check_if_samples_can_be_combined_with_bcftools(
             files_to_download=files_to_download,
             vcf_dimensions_data=vcf_dimensions_data,
         )
-        sample_and_filename_subset = [
-            entry for entry in sample_and_filename_subset if entry.filename in files_to_download
-        ]
 
-    _check_if_samples_can_be_combined_with_bcftools(
-        files_to_download=files_to_download,
-        vcf_dimensions_data=vcf_dimensions_data,
-    )
+        # Measure download operation resources
+        # Memory: Capture baseline before download, then measure incremental memory increase (delta)
+        if worker_settings.metrics.enabled_per_task:
+            download_cpu_start = process.cpu_times()
+            download_mem_baseline = process.memory_info().rss
+            download_memory_monitor = MemoryMonitor(process, sample_interval=0.5, baseline_memory=download_mem_baseline)
+            download_memory_monitor.start()
+            download_start = time.time()
 
-    # Measure download operation resources
-    # Memory: Capture baseline before download, then measure incremental memory increase (delta)
-    if worker_settings.metrics.enabled_per_task:
-        download_cpu_start = process.cpu_times()
-        download_mem_baseline = process.memory_info().rss
-        download_memory_monitor = MemoryMonitor(process, sample_interval=0.5, baseline_memory=download_mem_baseline)
-        download_memory_monitor.start()
-        download_start = time.time()
+        logger.info("Started downloading VCF files from S3 to worker")
 
-    logger.info("Started downloading VCF files from S3 to worker")
-
-    vcf_paths = _download_vcf_files(
-        files_to_download=files_to_download,
-        bucket_name=bucket_name,
-        s3_file_manager=s3_file_manager,
-    )
-
-    logger.info("Finished downloading VCF files from S3 to worker")
-
-    if worker_settings.metrics.enabled_per_task:
-        download_walltime = time.time() - download_start
-        download_memory_stats = download_memory_monitor.stop()
-        download_cpu_end = process.cpu_times()
-        download_cpu_used = (download_cpu_end.user + download_cpu_end.system) - (
-            download_cpu_start.user + download_cpu_start.system
-        )
-        download_mem_peak_delta = download_memory_stats["peak_bytes"]
-        download_mem_avg_delta = download_memory_stats["avg_bytes"]
-        logger.debug(
-            f"VCF download from S3 to worker took (walltime): {download_walltime:.2f}s, CPU: {download_cpu_used:.2f}s"
+        vcf_paths = _download_vcf_files(
+            files_to_download=files_to_download,
+            bucket_name=bucket_name,
+            s3_file_manager=s3_file_manager,
         )
 
-    bcftools_inputs = BCFToolsInput(
-        sample_and_filename_subset=sample_and_filename_subset,
-        sampleIDs=resolved_sample_mode_results.unique_sample_ids,
-        filenames=[path.name for path in vcf_paths],
-        # In all-samples mode there is no need to auto-inject "-s", and doing so can create very large command lines.
-        auto_sample_injection=sample_selection_mode != VCFQuerySampleSelectionMode.ALL_SAMPLES,
-    )
+        logger.info("Finished downloading VCF files from S3 to worker")
 
-    logger.info("Started bcftools subprocesses")
+        if worker_settings.metrics.enabled_per_task:
+            download_walltime = time.time() - download_start
+            download_memory_stats = download_memory_monitor.stop()
+            download_cpu_end = process.cpu_times()
+            download_cpu_used = (download_cpu_end.user + download_cpu_end.system) - (
+                download_cpu_start.user + download_cpu_start.system
+            )
+            download_mem_peak_delta = download_memory_stats["peak_bytes"]
+            download_mem_avg_delta = download_memory_stats["avg_bytes"]
+            logger.debug(
+                f"VCF download from S3 to worker took (walltime): {download_walltime:.2f}s, CPU: {download_cpu_used:.2f}s"
+            )
 
-    # Execute bcftools and get true subprocess metrics
-    # Let validation exceptions (BcftoolsPipeEmptyCommandError, BcftoolsPipeUnsupportedCommandError,
-    # SidecarInvalidFilterError) propagate to mark task as FAILURE. Otherwise the tasks will incorrectly be marked as SUCCESS.
-    manager = BcftoolsQueryManager(enable_subprocess_monitoring=worker_settings.metrics.enabled_per_task)
-    output_file, bcftools_metrics = manager.execute_pipe(
-        command=command,
-        bcftools_inputs=bcftools_inputs,
-        job_id=job_id,
-    )
-    logger.info("Finished bcftools subprocesses")
+        bcftools_inputs = BCFToolsInput(
+            sample_and_filename_subset=sample_and_filename_subset,
+            sampleIDs=resolved_sample_mode_results.unique_sample_ids,
+            filenames=[path.name for path in vcf_paths],
+            # In all-samples mode there is no need to auto-inject "-s", and doing so can create very large command lines.
+            auto_sample_injection=sample_selection_mode != VCFQuerySampleSelectionMode.ALL_SAMPLES,
+        )
 
-    bcftools_cpu_used = bcftools_metrics.get("cpu_seconds", 0.0)
-    bcftools_mem_peak = bcftools_metrics.get("peak_memory_bytes", 0)
-    bcftools_mem_avg = bcftools_metrics.get("avg_memory_bytes", 0)
-    bcftools_walltime = bcftools_metrics.get("walltime_seconds", 0.0)
+        logger.info("Started bcftools subprocesses")
 
-    _upload_results_file(output_file=output_file, bucket_name=bucket_name, s3_file_manager=s3_file_manager)
-    _delete_job_files_from_worker(vcf_paths=vcf_paths, metadata_path=metadata_path, output_file=output_file)
+        # Execute bcftools and get true subprocess metrics
+        # Let validation exceptions (BcftoolsPipeEmptyCommandError, BcftoolsPipeUnsupportedCommandError,
+        # SidecarInvalidFilterError) propagate to mark task as FAILURE. Otherwise the tasks will incorrectly be marked as SUCCESS.
+        manager = BcftoolsQueryManager(enable_subprocess_monitoring=worker_settings.metrics.enabled_per_task)
+        output_file, bcftools_metrics = manager.execute_pipe(
+            command=command,
+            bcftools_inputs=bcftools_inputs,
+            job_id=job_id,
+        )
+        logger.info("Finished bcftools subprocesses")
 
+        bcftools_cpu_used = bcftools_metrics.get("cpu_seconds", 0.0)
+        bcftools_mem_peak = bcftools_metrics.get("peak_memory_bytes", 0)
+        bcftools_mem_avg = bcftools_metrics.get("avg_memory_bytes", 0)
+        bcftools_walltime = bcftools_metrics.get("walltime_seconds", 0.0)
+
+        _upload_results_file(output_file=output_file, bucket_name=bucket_name, s3_file_manager=s3_file_manager)
+        task_succeeded = True
+
+    except Exception as e:
+        # This ensures the user gets any error message in their log file
+        logger.exception(f"An error occurred running your task: {str(e)}", exc_info=True)
+        raise
+
+    finally:
+        root_logger.removeHandler(log_handler)
+        log_handler.close()
+
+        status_str = "SUCCESS" if task_succeeded else "FAILURE"
+        _update_log_header(log_file=log_file, find="JOB_STATUS_PLACEHOLDER", replace=status_str)
+        # the selection mode is determined during task execution, hence updated in finally block
+        _add_sample_selection_info_to_log_header(
+            log_file=log_file,
+            sample_selection_mode=sample_selection_mode,
+            tsv_filter=tsv_filter,
+            samples=samples,
+        )
+
+        _upload_log_file(log_file=log_file, bucket_name=bucket_name, s3_file_manager=s3_file_manager)
+        _delete_job_files_from_worker(
+            vcf_paths=vcf_paths,
+            metadata_path=metadata_path,
+            output_file=output_file,
+            log_file=log_file,
+        )
     if worker_settings.metrics.enabled_per_task:
         memory_stats = memory_monitor.stop()
         cpu_end = process.cpu_times()
@@ -496,7 +554,7 @@ def bcftools_pipe_task(
         )
         _record_task_metrics(task_metrics)
 
-    return {"status": "completed", "output_file": str(output_file)}
+    return {"status": "completed", "output_file": str(output_file), "log_file": str(log_file)}
 
 
 @app.task(name="tasks.update_vcf_dimensions_task")
@@ -622,6 +680,7 @@ def update_vcf_dimensions_task(
 
             except Exception as e:
                 logger.error(f"Error indexing {s3_key}: {str(e)}")
+                _delete_job_files_from_worker(vcf_paths=vcf_paths)
                 return {"status": "error", "error": str(e), "task_id": task_id}
 
         _delete_job_files_from_worker(vcf_paths=vcf_paths)
@@ -721,6 +780,14 @@ def _download_vcf_files(files_to_download: list[str], bucket_name: str, s3_file_
     return downloaded_files
 
 
+def _get_bcftools_version() -> str:
+    try:
+        result = subprocess.run(["bcftools", "--version-only"], capture_output=True, text=True, check=True, timeout=5)
+    except Exception:
+        return "unknown"
+    return result.stdout.splitlines()[0].strip()
+
+
 def _upload_results_file(output_file: Path, bucket_name: str, s3_file_manager: S3FileManager) -> None:
     """
     Upon completion of the task, upload the results file to the specified bucket.
@@ -729,6 +796,47 @@ def _upload_results_file(output_file: Path, bucket_name: str, s3_file_manager: S
         to_upload={output_file.name: output_file},
         bucket_name=bucket_name,
     )
+
+
+def _upload_log_file(log_file: Path, bucket_name: str, s3_file_manager: S3FileManager) -> None:
+    """
+    Upload the per-job log file to S3.
+    Unlike a results file upload, a failed log file upload should not cause the task to be marked as failed.
+    """
+    try:
+        _ = s3_file_manager.upload_files(
+            to_upload={log_file.name: log_file},
+            bucket_name=bucket_name,
+        )
+    except ClientError as e:
+        logger.error(f"Could not upload log file {log_file.name} to S3: {e}")
+
+
+def _update_log_header(log_file: Path, find: str, replace: str) -> None:
+    """Update the log header by replacing a placeholder string with the provided replacement string."""
+    log_file.write_text(log_file.read_text(encoding="utf-8").replace(find, replace), encoding="utf-8")
+
+
+def _add_sample_selection_info_to_log_header(
+    log_file: Path,
+    sample_selection_mode: VCFQuerySampleSelectionMode,
+    tsv_filter: str | None,
+    samples: list[str] | None,
+    metadata_tsv_name: str | None = None,
+) -> None:
+    """
+    Update the log file header based on the user defined sample selection mode.
+    """
+    if sample_selection_mode == VCFQuerySampleSelectionMode.ALL_SAMPLES:
+        _update_log_header(log_file, find="SAMPLE_FILTER_PLACEHOLDER", replace="All samples selected")
+    elif sample_selection_mode == VCFQuerySampleSelectionMode.CLI_SAMPLES:
+        replace_text = f"Filter by sample IDs\nSamples selected: {', '.join(samples)}"
+        _update_log_header(log_file, find="SAMPLE_FILTER_PLACEHOLDER", replace=replace_text)
+    elif sample_selection_mode == VCFQuerySampleSelectionMode.SAMPLE_METADATA_QUERY:
+        replace_text = f"Sample metadata query \nTSV query string: '{tsv_filter}'"
+        _update_log_header(log_file, find="SAMPLE_FILTER_PLACEHOLDER", replace=replace_text)
+    else:
+        _update_log_header(log_file, find="SAMPLE_FILTER_PLACEHOLDER", replace="Unknown")
 
 
 def _remove_stale_dimensions_db_entries(

--- a/packages/divbase-api/src/divbase_api/worker/tasks.py
+++ b/packages/divbase-api/src/divbase_api/worker/tasks.py
@@ -1,4 +1,5 @@
 import dataclasses
+import functools
 import logging
 import subprocess
 import time
@@ -10,7 +11,7 @@ from zoneinfo import ZoneInfo
 
 import psutil
 import structlog
-from botocore.exceptions import ClientError
+from botocore.exceptions import BotoCoreError
 from celery import Celery
 from celery.signals import (
     after_task_publish,
@@ -372,11 +373,12 @@ def bcftools_pipe_task(
     root_logger = logging.getLogger()
     root_logger.addHandler(log_handler)
 
-    # assign here so even if early exit from error the finally block will be able to clean them up.
+    # assigned here so even if early exit from error the finally block will be able to clean them up.
     vcf_paths: list[Path] = []
     metadata_path: Path | None = None
     output_file: Path | None = None
     task_succeeded = False
+    sample_selection_mode: VCFQuerySampleSelectionMode | None = None
     try:
         with SyncSessionLocal() as db:
             vcf_dimensions_data = get_vcf_metadata_by_project(project_id=project_id, db=db)
@@ -510,17 +512,19 @@ def bcftools_pipe_task(
     finally:
         root_logger.removeHandler(log_handler)
         log_handler.close()
-
-        status_str = "SUCCESS" if task_succeeded else "FAILURE"
-        _update_log_header(log_file=log_file, find="JOB_STATUS_PLACEHOLDER", replace=status_str)
-        # the selection mode is determined during task execution, hence updated in finally block
-        _add_sample_selection_info_to_log_header(
-            log_file=log_file,
+        job_status_text = "SUCCESS" if task_succeeded else "FAILURE"
+        sample_filter_text = _build_sample_selection_replacement(
             sample_selection_mode=sample_selection_mode,
             tsv_filter=tsv_filter,
             samples=samples,
         )
-
+        _update_log_header(
+            log_file,
+            replacements={
+                "JOB_STATUS_PLACEHOLDER": job_status_text,
+                "SAMPLE_FILTER_PLACEHOLDER": sample_filter_text,
+            },
+        )
         _upload_log_file(log_file=log_file, bucket_name=bucket_name, s3_file_manager=s3_file_manager)
         _delete_job_files_from_worker(
             vcf_paths=vcf_paths,
@@ -780,6 +784,7 @@ def _download_vcf_files(files_to_download: list[str], bucket_name: str, s3_file_
     return downloaded_files
 
 
+@functools.lru_cache()
 def _get_bcftools_version() -> str:
     try:
         result = subprocess.run(["bcftools", "--version-only"], capture_output=True, text=True, check=True, timeout=5)
@@ -808,35 +813,31 @@ def _upload_log_file(log_file: Path, bucket_name: str, s3_file_manager: S3FileMa
             to_upload={log_file.name: log_file},
             bucket_name=bucket_name,
         )
-    except ClientError as e:
-        logger.error(f"Could not upload log file {log_file.name} to S3: {e}")
+    except (BotoCoreError, FileNotFoundError) as e:
+        logger.exception(f"Could not upload log file {log_file.name} to S3: {e}")
 
 
-def _update_log_header(log_file: Path, find: str, replace: str) -> None:
-    """Update the log header by replacing a placeholder string with the provided replacement string."""
-    log_file.write_text(log_file.read_text(encoding="utf-8").replace(find, replace), encoding="utf-8")
+def _update_log_header(log_file: Path, replacements: dict[str, str]) -> None:
+    """find and replace all placeholder in the user log file header."""
+    content = log_file.read_text(encoding="utf-8")
+    for old, new in replacements.items():
+        content = content.replace(old, new, count=1)
+    log_file.write_text(content, encoding="utf-8")
 
 
-def _add_sample_selection_info_to_log_header(
-    log_file: Path,
-    sample_selection_mode: VCFQuerySampleSelectionMode,
+def _build_sample_selection_replacement(
+    sample_selection_mode: VCFQuerySampleSelectionMode | None,
     tsv_filter: str | None,
     samples: list[str] | None,
-    metadata_tsv_name: str | None = None,
-) -> None:
-    """
-    Update the log file header based on the user defined sample selection mode.
-    """
+) -> str:
+    """Return the sample selection description for the user log file header."""
     if sample_selection_mode == VCFQuerySampleSelectionMode.ALL_SAMPLES:
-        _update_log_header(log_file, find="SAMPLE_FILTER_PLACEHOLDER", replace="All samples selected")
+        return "All samples selected"
     elif sample_selection_mode == VCFQuerySampleSelectionMode.CLI_SAMPLES:
-        replace_text = f"Filter by sample IDs\nSamples selected: {', '.join(samples)}"
-        _update_log_header(log_file, find="SAMPLE_FILTER_PLACEHOLDER", replace=replace_text)
+        return f"Filter by sample IDs\nSamples selected: {', '.join(samples)}"
     elif sample_selection_mode == VCFQuerySampleSelectionMode.SAMPLE_METADATA_QUERY:
-        replace_text = f"Sample metadata query \nTSV query string: '{tsv_filter}'"
-        _update_log_header(log_file, find="SAMPLE_FILTER_PLACEHOLDER", replace=replace_text)
-    else:
-        _update_log_header(log_file, find="SAMPLE_FILTER_PLACEHOLDER", replace="Unknown")
+        return f"Sample metadata query\nTSV query string: '{tsv_filter}'"
+    return "Unknown"
 
 
 def _remove_stale_dimensions_db_entries(

--- a/packages/divbase-api/src/divbase_api/worker/tasks.py
+++ b/packages/divbase-api/src/divbase_api/worker/tasks.py
@@ -1078,22 +1078,24 @@ def _delete_job_files_from_worker(
     """
     vcf_paths = vcf_paths or []
     for vcf_path in vcf_paths:
-        vcf_path.unlink(missing_ok=True)
-        logger.info(f"Deleted {vcf_path} from worker.")
+        if vcf_path.exists():
+            vcf_path.unlink(missing_ok=True)
+            logger.info(f"Deleted {vcf_path} from worker.")
 
         csi_path = vcf_path.with_suffix(vcf_path.suffix + ".csi")
-        csi_path.unlink(missing_ok=True)
-        logger.info(f"Deleted CSI index {csi_path} from worker.")
+        if csi_path.exists():
+            csi_path.unlink(missing_ok=True)
+            logger.info(f"Deleted CSI index {csi_path} from worker.")
 
-    if metadata_path:
+    if metadata_path and metadata_path.exists():
         metadata_path.unlink(missing_ok=True)
         logger.info(f"Deleted {metadata_path} from worker.")
 
-    if output_file:
+    if output_file and output_file.exists():
         output_file.unlink(missing_ok=True)
         logger.info(f"Deleted {output_file} from worker.")
 
-    if log_file:
+    if log_file and log_file.exists():
         log_file.unlink(missing_ok=True)
         logger.info(f"Deleted {log_file} from worker.")
 

--- a/packages/divbase-api/src/divbase_api/worker/tasks.py
+++ b/packages/divbase-api/src/divbase_api/worker/tasks.py
@@ -275,6 +275,8 @@ def sample_metadata_query_task(
     user_id: int,
 ) -> dict:
     """Run a sample metadata query task as a Celery task."""
+    # assigned now to avoid UnboundLocalError in the finally block
+    metadata_path: Path | None = None
     try:
         task_id = sample_metadata_query_task.request.id
         s3_file_manager = _create_s3_file_manager()

--- a/packages/divbase-cli/src/divbase_cli/cli_commands/query_cli.py
+++ b/packages/divbase-cli/src/divbase_cli/cli_commands/query_cli.py
@@ -268,7 +268,7 @@ def get_results_from_query_job_by_task_id(
     )
 
     resolved_download_dir = resolve_download_dir(download_dir=download_dir)
-    log_filename = f"{QUERY_RESULTS_FILE_PREFIX}{task_id}.txt"
+    log_filename = f"{QUERY_RESULTS_FILE_PREFIX}{task_id}.log"
 
     if task_status == "SUCCESS":
         result_filename = f"{QUERY_RESULTS_FILE_PREFIX}{task_id}.vcf.gz"

--- a/packages/divbase-cli/src/divbase_cli/cli_commands/query_cli.py
+++ b/packages/divbase-cli/src/divbase_cli/cli_commands/query_cli.py
@@ -281,12 +281,12 @@ def get_results_from_query_job_by_task_id(
             dry_run=False,
             project_version=None,
         )
-        # TODO - should we pretty print here if this is for programmtic use?
         _pretty_print_download_results(download_results=download_results)
     else:
         print(f"Task {task_id} failed. Run 'divbase-cli task-history id {task_id}' for more details on the failure.")
         print(
-            f"A log file of the task can be downloaded and viewed using the command: divbase-cli files download {log_filename}"
+            f"The task's log file can be downloaded for debugging using the command:\n'divbase-cli files download {log_filename}'\n"
+            f"You can view the log file contents directly in your terminal with:\n'divbase-cli files stream {log_filename}'"
         )
         raise typer.Exit(code=1)
 

--- a/packages/divbase-cli/src/divbase_cli/cli_commands/query_cli.py
+++ b/packages/divbase-cli/src/divbase_cli/cli_commands/query_cli.py
@@ -9,11 +9,6 @@ If sample metadata query:
 If bcftools query:
     a task id is returned which can be used to check the status of the job.
     After task completed, a merged VCF file will be added to the project's storage bucket which can be downloaded by the user.
-
-
-TODO:
-- Ability to download results file given task id with the file cli?
--
 """
 
 import logging
@@ -272,20 +267,27 @@ def get_results_from_query_job_by_task_id(
         divbase_url=logged_in_url, task_id=task_id, timeout_mins=max_wait_mins
     )
 
+    resolved_download_dir = resolve_download_dir(download_dir=download_dir)
+    log_filename = f"{QUERY_RESULTS_FILE_PREFIX}{task_id}.txt"
+
     if task_status == "SUCCESS":
         result_filename = f"{QUERY_RESULTS_FILE_PREFIX}{task_id}.vcf.gz"
         download_results = download_files_command(
             divbase_base_url=logged_in_url,
             project_name=project_config.name,
             raw_files_input=[result_filename],
-            download_dir=resolve_download_dir(download_dir=download_dir),
+            download_dir=resolved_download_dir,
             verify_checksums=True,
             dry_run=False,
             project_version=None,
         )
+        # TODO - should we pretty print here if this is for programmtic use?
         _pretty_print_download_results(download_results=download_results)
     else:
         print(f"Task {task_id} failed. Run 'divbase-cli task-history id {task_id}' for more details on the failure.")
+        print(
+            f"A log file of the task can be downloaded and viewed using the command: divbase-cli files download {log_filename}"
+        )
         raise typer.Exit(code=1)
 
 

--- a/packages/divbase-lib/src/divbase_lib/api_schemas/queries.py
+++ b/packages/divbase-lib/src/divbase_lib/api_schemas/queries.py
@@ -2,7 +2,7 @@
 Schemas for query routes.
 """
 
-from typing import Optional, Self
+from typing import Self
 
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
@@ -206,4 +206,5 @@ class BcftoolsQueryTaskResult(BaseModel):
     """BCFtools query task result details. Based on the return of tasks.bcftools_query."""
 
     output_file: str
-    status: Optional[str] = None
+    status: str | None = None
+    log_file: str | None = None

--- a/tests/e2e_integration/cli_commands/test_query_cli.py
+++ b/tests/e2e_integration/cli_commands/test_query_cli.py
@@ -229,7 +229,7 @@ class TestQueryVCFSuccess:
     ):
         """
         Test running a bcftools pipe query using the CLI.
-        We test one case where the job should succeed and one where is should fail mid run.
+        We test one case where the job should succeed and one where the job should fail mid run.
         In both cases we should get back a log file and in the success case we should also get back the results file.
         """
         project_name = CONSTANTS["QUERY_PROJECT"]

--- a/tests/e2e_integration/cli_commands/test_query_cli.py
+++ b/tests/e2e_integration/cli_commands/test_query_cli.py
@@ -225,7 +225,7 @@ class TestQueryVCFSuccess:
         run_update_dimensions,
         project_map,
     ):
-        """Test running a bcftools pipe query using the CLI."""
+        """Test running a bcftools pipe query using the CLI completes and provides a results and log file for the task."""
         project_name = CONSTANTS["QUERY_PROJECT"]
         project_id = project_map[project_name]
         bucket_name = CONSTANTS["PROJECT_TO_BUCKET_MAP"][project_name]
@@ -249,9 +249,16 @@ class TestQueryVCFSuccess:
         result = runner.invoke(app, command)
 
         assert result.exit_code == 0
-        assert any(QUERY_RESULTS_FILE_PREFIX in line for line in result.stdout.splitlines()), (
-            f"No {QUERY_RESULTS_FILE_PREFIX} VCF file found in output.\nfiles ls output:\n{result.stdout}"
-        )
+        assert f"{QUERY_RESULTS_FILE_PREFIX}{user_task_id}.vcf.gz" in result.stdout
+        log_file = f"{QUERY_RESULTS_FILE_PREFIX}{user_task_id}.log"
+        assert log_file in result.stdout
+
+        command = f"files download {log_file} --project {project_name}"
+        result = runner.invoke(app, command)
+        assert result.exit_code == 0
+        assert Path(log_file).exists()
+        log_contents = Path(log_file).read_text()
+        assert "Job Status: SUCCESS" in log_contents
 
     @pytest.mark.parametrize(
         "files_to_upload, metadata_tsv_name, sample_selection_args, bcftools_view_command, expected_checksum",

--- a/tests/e2e_integration/cli_commands/test_query_cli.py
+++ b/tests/e2e_integration/cli_commands/test_query_cli.py
@@ -260,6 +260,52 @@ class TestQueryVCFSuccess:
         log_contents = Path(log_file).read_text()
         assert "Job Status: SUCCESS" in log_contents
 
+    def test_query_vcf_failure_uploads_log_with_error_message(
+        self,
+        CONSTANTS,
+        project_map,
+        logged_in_edit_user_with_existing_config,
+        run_update_dimensions,
+    ):
+        """Test a failing query vcf task still uploads a log file containing failure status and the error message."""
+        project_name = CONSTANTS["QUERY_PROJECT"]
+        project_id = project_map[project_name]
+        bucket_name = CONSTANTS["PROJECT_TO_BUCKET_MAP"][project_name]
+        user_id = 1
+        run_update_dimensions(
+            bucket_name=bucket_name, project_id=project_id, project_name=project_name, user_id=user_id
+        )
+        tsv_filter = "Area:West of Ireland,Northern Portugal;"
+        arg_command = "view -r 100000:15000000-25000000"  # specifying a chromosome that does not exist in the fixtures to cause the query to fail
+
+        # Job should be accepted but fail during the run.
+        command = f"query vcf --tsv-filter '{tsv_filter}' --command '{arg_command}' --project {project_name} "
+        result = runner.invoke(app, command)
+        assert result.exit_code == 0
+        assert "Job submitted" in result.stdout
+
+        user_task_id = result.stdout.strip().split()[-1]
+        task_state, task_stdout = wait_for_task_terminal_state_using_CLI(user_task_id=user_task_id)
+        assert task_state == "FAILURE"
+
+        # log file should be present, but not the results file
+        command = f"files ls --project {project_name} --include-results-files"
+        result = runner.invoke(app, command)
+
+        assert result.exit_code == 0
+        assert f"{QUERY_RESULTS_FILE_PREFIX}{user_task_id}.vcf.gz" not in result.stdout
+        log_file = f"{QUERY_RESULTS_FILE_PREFIX}{user_task_id}.log"
+        assert log_file in result.stdout
+
+        command = f"files download {log_file} --project {project_name}"
+        result = runner.invoke(app, command)
+        assert result.exit_code == 0
+        assert Path(log_file).exists()
+        log_contents = Path(log_file).read_text()
+        assert "Job Status: FAILURE" in log_contents
+        assert "TaskUserError" in log_contents
+        assert "no vcf files in the project that fulfill the query" in log_contents.lower()
+
     @pytest.mark.parametrize(
         "files_to_upload, metadata_tsv_name, sample_selection_args, bcftools_view_command, expected_checksum",
         [

--- a/tests/e2e_integration/cli_commands/test_query_cli.py
+++ b/tests/e2e_integration/cli_commands/test_query_cli.py
@@ -218,14 +218,20 @@ class TestQueryTSVSuccess:
 class TestQueryVCFSuccess:
     """Successful query vcf CLI test cases."""
 
-    def test_bcftools_pipe_query(
+    @pytest.mark.parametrize("should_succeed", [True, False])
+    def test_basic_bcftools_pipe_query_success_and_failure(
         self,
         CONSTANTS,
         logged_in_edit_user_with_existing_config,
         run_update_dimensions,
         project_map,
+        should_succeed,
     ):
-        """Test running a bcftools pipe query using the CLI completes and provides a results and log file for the task."""
+        """
+        Test running a bcftools pipe query using the CLI.
+        We test one case where the job should succeed and one where is should fail mid run.
+        In both cases we should get back a log file and in the success case we should also get back the results file.
+        """
         project_name = CONSTANTS["QUERY_PROJECT"]
         project_id = project_map[project_name]
         bucket_name = CONSTANTS["PROJECT_TO_BUCKET_MAP"][project_name]
@@ -234,8 +240,12 @@ class TestQueryVCFSuccess:
             bucket_name=bucket_name, project_id=project_id, project_name=project_name, user_id=user_id
         )
         tsv_filter = "Area:West of Ireland,Northern Portugal;"
-        arg_command = "view -r 21:15000000-25000000"
+        if should_succeed:
+            arg_command = "view -r 21:15000000-25000000"
+        else:
+            arg_command = "view -r 100000:15000000-25000000"  # range that does not exist.
 
+        # both cases should be able to submit the job
         command = f"query vcf --tsv-filter '{tsv_filter}' --command '{arg_command}' --project {project_name} "
         result = runner.invoke(app, command)
         assert result.exit_code == 0
@@ -243,68 +253,35 @@ class TestQueryVCFSuccess:
 
         user_task_id = result.stdout.strip().split()[-1]
         task_state, task_stdout = wait_for_task_terminal_state_using_CLI(user_task_id=user_task_id)
-        assert task_state == "SUCCESS", f"Task failed. task-history output:\n{task_stdout}"
+        if should_succeed:
+            assert task_state == "SUCCESS"
+        else:
+            assert task_state == "FAILURE"
 
+        # both should have log file
         command = f"files ls --project {project_name} --include-results-files"
         result = runner.invoke(app, command)
-
         assert result.exit_code == 0
-        assert f"{QUERY_RESULTS_FILE_PREFIX}{user_task_id}.vcf.gz" in result.stdout
         log_file = f"{QUERY_RESULTS_FILE_PREFIX}{user_task_id}.log"
         assert log_file in result.stdout
+
+        if should_succeed:
+            assert f"{QUERY_RESULTS_FILE_PREFIX}{user_task_id}.vcf.gz" in result.stdout
+        else:
+            assert f"{QUERY_RESULTS_FILE_PREFIX}{user_task_id}.vcf.gz" not in result.stdout
 
         command = f"files download {log_file} --project {project_name}"
         result = runner.invoke(app, command)
         assert result.exit_code == 0
         assert Path(log_file).exists()
         log_contents = Path(log_file).read_text()
-        assert "Job Status: SUCCESS" in log_contents
 
-    def test_query_vcf_failure_uploads_log_with_error_message(
-        self,
-        CONSTANTS,
-        project_map,
-        logged_in_edit_user_with_existing_config,
-        run_update_dimensions,
-    ):
-        """Test a failing query vcf task still uploads a log file containing failure status and the error message."""
-        project_name = CONSTANTS["QUERY_PROJECT"]
-        project_id = project_map[project_name]
-        bucket_name = CONSTANTS["PROJECT_TO_BUCKET_MAP"][project_name]
-        user_id = 1
-        run_update_dimensions(
-            bucket_name=bucket_name, project_id=project_id, project_name=project_name, user_id=user_id
-        )
-        tsv_filter = "Area:West of Ireland,Northern Portugal;"
-        arg_command = "view -r 100000:15000000-25000000"  # specifying a chromosome that does not exist in the fixtures to cause the query to fail
-
-        # Job should be accepted but fail during the run.
-        command = f"query vcf --tsv-filter '{tsv_filter}' --command '{arg_command}' --project {project_name} "
-        result = runner.invoke(app, command)
-        assert result.exit_code == 0
-        assert "Job submitted" in result.stdout
-
-        user_task_id = result.stdout.strip().split()[-1]
-        task_state, task_stdout = wait_for_task_terminal_state_using_CLI(user_task_id=user_task_id)
-        assert task_state == "FAILURE"
-
-        # log file should be present, but not the results file
-        command = f"files ls --project {project_name} --include-results-files"
-        result = runner.invoke(app, command)
-
-        assert result.exit_code == 0
-        assert f"{QUERY_RESULTS_FILE_PREFIX}{user_task_id}.vcf.gz" not in result.stdout
-        log_file = f"{QUERY_RESULTS_FILE_PREFIX}{user_task_id}.log"
-        assert log_file in result.stdout
-
-        command = f"files download {log_file} --project {project_name}"
-        result = runner.invoke(app, command)
-        assert result.exit_code == 0
-        assert Path(log_file).exists()
-        log_contents = Path(log_file).read_text()
-        assert "Job Status: FAILURE" in log_contents
-        assert "TaskUserError" in log_contents
-        assert "no vcf files in the project that fulfill the query" in log_contents.lower()
+        if should_succeed:
+            assert "Job Status: SUCCESS" in log_contents
+        else:
+            assert "Job Status: FAILURE" in log_contents
+            assert "TaskUserError" in log_contents
+            assert "no vcf files in the project that fulfill the query" in log_contents.lower()
 
     @pytest.mark.parametrize(
         "files_to_upload, metadata_tsv_name, sample_selection_args, bcftools_view_command, expected_checksum",

--- a/tests/e2e_integration/queries_integration/test_bcftools_tasks.py
+++ b/tests/e2e_integration/queries_integration/test_bcftools_tasks.py
@@ -572,7 +572,7 @@ def test_bcftools_pipe_cli_integration_with_eager_mode(
             bucket_name=bucket_name,
         )
 
-    def patched_delete_job_files_from_worker(vcf_paths=None, metadata_path=None, output_file=None):
+    def patched_delete_job_files_from_worker(vcf_paths=None, metadata_path=None, output_file=None, log_file=None):
         """
         Only delete the output file, using the correct path. Don't delete the fixtures, since they should persist.
         """

--- a/tests/e2e_integration/test_cleanup_expired_files.py
+++ b/tests/e2e_integration/test_cleanup_expired_files.py
@@ -267,7 +267,7 @@ def test_results_files_hard_deleted(
     tmp_path: Path,
 ):
     """
-    Validate that query job/task files are hard deleted after the retention window:
+    Validate that query job/task files and their associated log files are hard deleted after the retention window:
         - all versions and delete markers removed
         - true whether the file was soft-deleted or not (both paths exercised in one test).
     """
@@ -285,10 +285,21 @@ def test_results_files_hard_deleted(
     f.write_text("active results content")
     s3_file_manager.upload_files(bucket_name=bucket_name, to_upload={active_filename: f})
 
+    soft_deleted_log_filename = f"{QUERY_RESULTS_FILE_PREFIX}{tmp_path.name}.log"
+    f = tmp_path / soft_deleted_log_filename
+    f.write_text("log content")
+    s3_file_manager.upload_files(bucket_name=bucket_name, to_upload={soft_deleted_log_filename: f})
+    s3_file_manager.soft_delete_objects(objects=[soft_deleted_log_filename], bucket_name=bucket_name)
+
+    active_log_filename = f"{QUERY_RESULTS_FILE_PREFIX}{tmp_path.name}_active.log"
+    f = tmp_path / active_log_filename
+    f.write_text("active log content")
+    s3_file_manager.upload_files(bucket_name=bucket_name, to_upload={active_log_filename: f})
+
     mocked_now = datetime.now(timezone.utc) + timedelta(days=DEFAULT_RESULTS_FILES_RETENTION_DAYS + 1)
     _run_script_with_mocked_time(mocked_now)
 
-    for filename in (soft_deleted_filename, active_filename):
+    for filename in (soft_deleted_filename, active_filename, soft_deleted_log_filename, active_log_filename):
         versions = s3_file_manager.s3_client.list_object_versions(Bucket=bucket_name, Prefix=filename)
         assert not [v for v in versions.get("Versions", []) if v["Key"] == filename]
         assert not [m for m in versions.get("DeleteMarkers", []) if m["Key"] == filename]


### PR DESCRIPTION
NOTE: Pointed at non main branch for comparison purposes as follow on branch.

This PR covers giving a user a log file for when they submit a `query vcf` job to DivBase. Logs are given to the user in the case of both success or failure. 

The output from a log file looks something like this:
```
DivBase query vcf task log
=================
Job Status: SUCCESS
DivBase version: 0.1.0a4
BCFtools version: 1.22+htslib-1.22
Date: 2026-05-28 15:32:20 CEST
Project: local-project-3
Sample Selection Mode: All samples selected
User inputted bcftools command used: 'view -r 21:15000000-25000000'
Task ID: 62
DivBase internal task ID: 664d1852-65f0-4813-aac9-a72314e51672
=================

[info     ] 'view -r' query requires scaffold '21'. It is present in file 'HOM_20ind_17SNPs.21.vcf.gz'.
.... logging statements continue...
```

### Notes
- The existing cron job for deleting results files already would delete log files due to having same prefix, the test has been updated to validate this is the case. 
- The implementation involves creating a new logging FileHandler which is customized to be more user/human readable  (see `_simplify_user_log_events`). 
- The changes to tasks.pylook bigger than they are due to indentation of both the query vcf task and sample metadata task to ensure proper cleanup and make sure the user logs are always written out for the user and contain the error message. 

### Plan:
- Review from the :robot: 
- Consider adding a few more tests cases, including for a task that fails midway through. 
- Open up for review