### PR TITLE
PR: SQ-907: Support storage of PATs via OS keyring

### DIFF
--- a/docs/user-guides/account-management.md
+++ b/docs/user-guides/account-management.md
@@ -67,6 +67,9 @@ To create a PAT:
     - **Task history** — Allow you to use the token to view your entire task history, not filtered by project.
 4. Click **Create**. Copy the token immediately — it is shown **only once** and cannot be recovered afterwards.
 
+After creating your PAT, the website will show you two options on how to store and use the PAT. For more advice on how to use a PAT in scripts and HPC jobs, see [Using DivBase Programmatically](./using-divbase-programmatically.md#use-personal-access-tokens-to-authenticate-programmatically).
+
 You can have up to **5 active tokens** at a time. To revoke a token, click **Revoke** next to it on the Personal Access Tokens page.
 
-For how to use a PAT in scripts and HPC jobs, see [Using DivBase Programmatically](./using-divbase-programmatically.md#use-personal-access-tokens-to-authenticate-programmatically).
+!!! tip "Scope your token to what the job needs and when you need it for"
+    When creating the PAT, restrict it to the specific project(s) you need it for. Consider also setting an appropriate expiry date for the token. You can always revoke the token immediately if needed from the DivBase website.

--- a/docs/user-guides/using-divbase-programmatically.md
+++ b/docs/user-guides/using-divbase-programmatically.md
@@ -4,49 +4,59 @@ Below is a set of tips for users who want to use DivBase in scripts/pipelines/pr
 
 If you have any tips or suggestions to add to this page or any desired features, please let us know!
 
-## Use Personal Access Tokens to Authenticate programmatically
+## Use Personal Access Tokens to authenticate programmatically
 
-For scripts, pipelines, and HPC jobs the recommended approach is to use a **Personal Access Token (PAT)**. A PAT is a static bearer token that you create once via the website and pass to `divbase-cli` via an environment variable. When using a PAT, there is no login step and no password storage required.
+For scripts, pipelines, and HPC jobs the recommended approach is to use a **Personal Access Token (PAT)**. A PAT is a static bearer token that you create once via the website. When using a PAT, there is no login step and no password storage required.
 
-See [Account Management — Personal Access Tokens](./account-management.md#personal-access-tokens) for how to create/and remove PATs.
+See [Account Management — Personal Access Tokens](./account-management.md#personal-access-tokens) for how to create and revoke PATs.
 
-Once you have a token, set the `DIVBASE_API_PAT` environment variable to it. `divbase-cli` will automatically use it in every request.
+You can store/use a PAT in two ways
 
-!!! question "What if I have both an active login session and a Personal Access Token set?"
-    `divbase-cli` prioritises an active login session over a PAT. If you have both, the CLI will use the active session and ignore the PAT. To use the PAT, you would need to run `divbase-cli auth logout` first.
+### Option 1 — Let `divbase-cli` handle storing the PAT (recommended)
+
+After creating a PAT on the website, store it on your device by copy pasting the pre-filled commands shown on the website, it will look something like this:
+
+```bash
+# with an expiry date:
+divbase-cli auth add-pat "my-pat-name" --expires UNIX_TIMESTAMP
+# or without an expiry date:
+divbase-cli auth add-pat "my-pat-name"
+```
+
+You will be prompted to paste the token value. It is then stored securely in your OS keyring (or in a restricted file if no keyring is available) and used automatically on every subsequent `divbase-cli` command.
+
+```bash
+divbase-cli auth pat-info   # show name and expiry of the stored PAT
+divbase-cli auth rm-pat     # remove the stored PAT from this device
+```
+
+!!! info "This strategy works on HPC clusters"
+    On the login node with divbase-cli [installed as we recommend](./installation.md), store the PAT as described above. The token will be available to all your jobs running on the cluster, without needing to worry about setting any environment variables in your job scripts.
+
+### Option 2 — Environment variable
+
+Set `DIVBASE_API_PAT` in your shell or job script:
 
 ```bash
 export DIVBASE_API_PAT="divbase_pat_your_token_here"
 divbase-cli files ls
 ```
 
-When `DIVBASE_API_PAT` is set, `divbase-cli` does not need you to be logged in.
+You may prefer this if you want explicit per-job control of which token is used.
 
-### Example: Slurm job script
+1. Store it securely on your device using `divbase-cli auth add-pat` (recommended and works on HPC clusters!)
+2. Set it as an environment variable `DIVBASE_API_PAT` (can give you more control over which token is used when)
 
-The cleanest way to use a PAT in a SLURM job is to store the token in a restricted file and load it at job start:
+!!! question "What if I have both an active login session and a personal access token set?"
+    `divbase-cli` follows this priority order:
 
-```bash
-echo "divbase_pat_your_token_here" > ~/.divbase_pat
-chmod 600 ~/.divbase_pat  # only readable/writeable by the owner
-```
+    1. **Active login session** (from `divbase-cli auth login`) — highest priority
+    2. **`DIVBASE_API_PAT` environment variable**
+    3. **CLI-stored PAT** (from `divbase-cli auth add-pat`)
 
-Then in your SLURM script:
+    To use a PAT when you are also logged in, run `divbase-cli auth logout` first.
 
-```bash
-#!/bin/bash
-#SBATCH --job-name=my_divbase_job
-#SBATCH --time=24:00:00
-# ....
-
-export DIVBASE_API_PAT=$(cat ~/.divbase_pat)
-
-# Download the files you need
-divbase-cli files download my_data.vcf.gz
-```
-
-!!! tip "Scope your token to what the job needs and when you need it for"
-    When creating the PAT, restrict it to the specific project(s) you need it for. Consider also setting an appropriate expiry date for the token. You can always revoke the token immediately if needed from the DivBase website.
+    Your logged in account will have the same or more permissions that your PATs, this is why we follow this order.
 
 ## Parse divbase-cli files ls/info output programmatically
 

--- a/docs/user-guides/using-divbase-programmatically.md
+++ b/docs/user-guides/using-divbase-programmatically.md
@@ -12,9 +12,9 @@ See [Account Management — Personal Access Tokens](./account-management.md#pers
 
 You can store/use a PAT in two ways
 
-### Option 1 — Let `divbase-cli` handle storing the PAT (recommended)
+### (Recommended) — Let `divbase-cli` handle storing the PAT
 
-After creating a PAT on the website, store it on your device by copy pasting the pre-filled commands shown on the website, it will look something like this:
+After creating a PAT on the DivBase website, store it on your device by copy pasting the pre-filled commands shown on the website, it will look something like this:
 
 ```bash
 # with an expiry date:
@@ -23,7 +23,7 @@ divbase-cli auth add-pat "my-pat-name" --expires UNIX_TIMESTAMP
 divbase-cli auth add-pat "my-pat-name"
 ```
 
-You will be prompted to paste the token value. It is then stored securely in your OS keyring (or in a restricted file if no keyring is available) and used automatically on every subsequent `divbase-cli` command.
+You will be prompted to paste the token value. It will then be stored securely in your OS keyring (or in a restricted file if no keyring is available) and used automatically on every subsequent `divbase-cli` command.
 
 ```bash
 divbase-cli auth pat-info   # show name and expiry of the stored PAT
@@ -33,7 +33,7 @@ divbase-cli auth rm-pat     # remove the stored PAT from this device
 !!! info "This strategy works on HPC clusters"
     On the login node with divbase-cli [installed as we recommend](./installation.md), store the PAT as described above. The token will be available to all your jobs running on the cluster, without needing to worry about setting any environment variables in your job scripts.
 
-### Option 2 — Environment variable
+### (Not recommended alternative) — Store the PAT in an environment variable
 
 Set `DIVBASE_API_PAT` in your shell or job script:
 
@@ -44,8 +44,7 @@ divbase-cli files ls
 
 You may prefer this if you want explicit per-job control of which token is used.
 
-1. Store it securely on your device using `divbase-cli auth add-pat` (recommended and works on HPC clusters!)
-2. Set it as an environment variable `DIVBASE_API_PAT` (can give you more control over which token is used when)
+---
 
 !!! question "What if I have both an active login session and a personal access token set?"
     `divbase-cli` follows this priority order:

--- a/packages/divbase-api/src/divbase_api/frontend_routes/personal_access_tokens.py
+++ b/packages/divbase-api/src/divbase_api/frontend_routes/personal_access_tokens.py
@@ -191,8 +191,10 @@ async def create_pat_endpoint(
     if expires_at_dt:
         dt = expires_at_dt.astimezone(ZoneInfo("Europe/Stockholm"))
         expires_at_cet = dt.strftime("%Y-%m-%d %H:%M:%S %Z")
+        expires_at_unix = int(expires_at_dt.timestamp())
     else:
         expires_at_cet = None
+        expires_at_unix = None
 
     background_tasks.add_task(
         send_pat_created_email, email_to=current_user.email, pat_name=name, expires_at_cet=expires_at_cet
@@ -204,6 +206,7 @@ async def create_pat_endpoint(
             "current_user": current_user,
             "pat": pat,
             "expires_at_cet": expires_at_cet,
+            "expires_at_unix": expires_at_unix,
             "raw_token": raw_token.get_secret_value(),
             "project_name_by_id": project_name_by_id,
         },

--- a/packages/divbase-api/src/divbase_api/templates/pats_pages/personal_access_token_created.html
+++ b/packages/divbase-api/src/divbase_api/templates/pats_pages/personal_access_token_created.html
@@ -20,17 +20,6 @@
                 </p>
             </div>
 
-            {# Token display with copy button #}
-            <div class="card shadow-sm mb-4">
-                <div class="card-header">
-                    <h5 class="mb-0"><i class="bi bi-key me-2"></i>{{ pat.name }}</h5>
-                </div>
-                <div class="card-body">
-                    {% set to_copy = raw_token %}
-                    {% include "components/copy_to_clipboard.html" %}
-                </div>
-            </div>
-
             {# Token summary #}
             <div class="card shadow-sm mb-4">
                 <div class="card-header">
@@ -82,10 +71,30 @@
                     <h5 class="mb-0"><i class="bi bi-terminal me-2"></i>Using your token</h5>
                 </div>
                 <div class="card-body">
-                    <p class="text-muted small mb-2">Set the <code>DIVBASE_API_PAT</code> environment variable to be your token value and <code>divbase-cli</code> will use your token automatically — no login required.</p>
+                    <p class="fw-semibold mb-1">Recommended: Let divbase-cli store your token</p>
+                    <p class="text-muted small mb-2">
+                        The token will be stored securely on the device using your operating system's keyring. 
+                        divbase-cli will use it automatically on every command when you are not logged in. 
+                    </p>
+                    {% if expires_at_unix %}
+                    {% set to_copy = 'divbase-cli auth add-pat "' ~ pat.name ~ '" --expires ' ~ expires_at_unix %}
+                    {% else %}
+                    {% set to_copy = 'divbase-cli auth add-pat "' ~ pat.name ~ '"' %}
+                    {% endif %}
+                    {% include "components/copy_to_clipboard.html" %}
+                    
+                    <p class="text-muted small mb-2">You'll be prompted to paste in your token:</p>
+                    {% set to_copy = raw_token %}
+                    {% include "components/copy_to_clipboard.html" %}
+                    
+                    <hr class="my-3">
+                    <p class="fw-semibold mb-1">Alternative: environment variable</p>
+                    <p class="text-muted small mb-2">
+                        Set <code>DIVBASE_API_PAT</code> to your token value. 
+                        You may find this preferable for HPC job scripts and pipelines where per-job token control is needed. If both are set, the environment variable will take precedence.</p>
                     {% set to_copy = 'export DIVBASE_API_PAT=' ~ raw_token %}
                     {% include "components/copy_to_clipboard.html" %}
-                    <a href="{{ mkdocs_site_url }}/user-guides/using-divbase-programmatically/#use-personal-access-tokens-to-authenticate-programmatically" target="_blank">
+                    <a class="d-block mt-3" href="{{ mkdocs_site_url }}/user-guides/using-divbase-programmatically/#use-personal-access-tokens-to-authenticate-programmatically" target="_blank">
                         See the full usage guide on our documentation site.<i class="bi bi-box-arrow-up-right ms-1"></i>
                     </a>
                 </div>

--- a/packages/divbase-api/src/divbase_api/templates/pats_pages/personal_access_tokens.html
+++ b/packages/divbase-api/src/divbase_api/templates/pats_pages/personal_access_tokens.html
@@ -9,7 +9,7 @@
         <div class="scilife-subsection mt-3">
             <h2><i class="bi bi-key me-2"></i>Personal Access Tokens</h2>
             <p class="text-muted">Tokens for use with CLI pipelines and automated workflows. Treat them like passwords and store them securely. 
-                <a href="{{ mkdocs_site_url }}user-guides/account-management/#personal-access-tokens" target="_blank">Learn more <i class="bi bi-box-arrow-up-right ms-1"></i></a>
+                <a href="{{ mkdocs_site_url }}/user-guides/account-management/#personal-access-tokens" target="_blank">Learn more <i class="bi bi-box-arrow-up-right ms-1"></i></a>
             </p>
         </div>
         <a href="/pats/new" class="btn scilife-confirm-button flex-shrink-0 ms-3">
@@ -154,6 +154,12 @@
             {% endif %}
         </div>
     </div>
+
+    {% if pats %}
+    <p class="text-muted small mt-3">
+        <i class="bi bi-info-circle me-1"></i>Run <code>divbase-cli auth pat-info</code> to see which PAT, if any, is stored there.
+    </p>
+    {% endif %}
 
 </div>
 {% endblock %}

--- a/packages/divbase-cli/src/divbase_cli/cli_commands/auth_cli.py
+++ b/packages/divbase-cli/src/divbase_cli/cli_commands/auth_cli.py
@@ -14,12 +14,16 @@ from divbase_cli.cli_exceptions import DivBaseAPIConnectionError, DivBaseAPIErro
 from divbase_cli.config_resolver import resolve_url_for_non_project_specific_commands
 from divbase_cli.services.announcements import get_and_display_announcements
 from divbase_cli.user_auth import (
+    PATData,
     check_existing_session,
+    delete_stored_pat,
+    load_stored_user_pat,
     login_to_divbase,
     logout_of_divbase,
     make_authenticated_request,
 )
 from divbase_cli.user_config import load_user_config
+from divbase_lib.divbase_constants import PAT_TOKEN_PREFIX
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +82,85 @@ def logout():
     """
     logout_of_divbase()
     print("Logged out successfully.")
+
+
+@auth_app.command("add-pat")
+def add_pat(
+    name: str = typer.Argument(..., help="Name of the personal access token (PAT). E.g. 'work-laptop-pat'"),
+    expires_unix_timestamp: int = typer.Option(
+        None,
+        "--expires",
+        "-e",
+        help="When the personal access token (PAT) expires (if it does), as a unix timestamp.",
+    ),
+    overwrite_existing: bool = typer.Option(
+        False, "--overwrite-existing", "-o", help="Overwrite the existing stored PAT if one already exists."
+    ),
+):
+    """
+    Add a personal access token (PAT) to your device for authentication with DivBase.
+
+    PATs are used for authenticating with the DivBase API instead of using your password, and are recommended for use in scripts and pipelines.
+    See https://scilifelabdatacentre.github.io/divbase/user-guides/using-divbase-programmatically/ for more details on how to create a personal access token.
+    You can only store one personal access token at a time.
+    """
+    existing = load_stored_user_pat()
+    if existing and not overwrite_existing:
+        print(
+            f"A personal access token named '{existing.name}' is already stored on your device \n"
+            f"It is due to expire on: {existing.pat_expiry_formatted()} \n"
+            "Append the flag --overwrite-existing (-o) to this command if you want to replace it. \n"
+            "You can only store one PAT at a time."
+        )
+        raise typer.Exit(code=1)
+
+    if expires_unix_timestamp and expires_unix_timestamp < int(datetime.now().timestamp()):
+        print("The expiry time you entered is in the past. Please enter a valid expiry time for the PAT.")
+        raise typer.Exit(code=1)
+
+    pat = SecretStr(
+        typer.prompt("please paste your personal access token now", hide_input=True, confirmation_prompt=False)
+    )
+    if not pat.get_secret_value().startswith(PAT_TOKEN_PREFIX):
+        print(
+            "It looks like the token you entered is not a valid personal access token. "
+            f"Please make sure you copied the entire token, including the '{PAT_TOKEN_PREFIX}' prefix."
+        )
+        raise typer.Exit(code=1)
+
+    pat_data = PATData(name=name, pat=pat, pat_expires_at=expires_unix_timestamp)
+    pat_data.dump_pat_data()
+    print(f"Personal access token '{name}' stored successfully.")
+
+
+@auth_app.command("rm-pat")
+def rm_pat():
+    """
+    Remove the stored personal access token from your device.
+
+    If no such token exists the command will still succeed.
+    """
+    delete_stored_pat()
+    print("If a personal access token was stored, it has now been removed.")
+
+
+@auth_app.command("pat-info")
+def pat_info():
+    """
+    Display information about the personal access token stored on this device, if any.
+
+    The token will not be displayed for security reasons, but the name and expiry time will be shown.
+    """
+    pat_data = load_stored_user_pat()
+    if not pat_data:
+        print("No personal access token stored on this device.")
+        return
+
+    if pat_data.pat_expires_at and pat_data.pat_expires_at <= datetime.now().timestamp():
+        print("[red]Warning: this PAT has expired.[/red]")
+
+    print(f"Name: {pat_data.name}")
+    print(f"Expires: {pat_data.pat_expiry_formatted()}")
 
 
 @auth_app.command("whoami")

--- a/packages/divbase-cli/src/divbase_cli/cli_commands/auth_cli.py
+++ b/packages/divbase-cli/src/divbase_cli/cli_commands/auth_cli.py
@@ -3,6 +3,7 @@ CLI subcommand for managing user auth with DivBase server.
 """
 
 import logging
+import time
 from datetime import datetime
 
 import typer
@@ -14,6 +15,7 @@ from divbase_cli.cli_exceptions import DivBaseAPIConnectionError, DivBaseAPIErro
 from divbase_cli.config_resolver import resolve_url_for_non_project_specific_commands
 from divbase_cli.services.announcements import get_and_display_announcements
 from divbase_cli.user_auth import (
+    PERSONAL_ACCESS_TOKEN_EXPIRED_MESSAGE,
     PATData,
     check_existing_session,
     delete_stored_pat,
@@ -92,6 +94,7 @@ def add_pat(
         "--expires",
         "-e",
         help="When the personal access token (PAT) expires (if it does), as a unix timestamp.",
+        min=1,
     ),
     overwrite_existing: bool = typer.Option(
         False, "--overwrite-existing", "-o", help="Overwrite the existing stored PAT if one already exists."
@@ -114,7 +117,7 @@ def add_pat(
         )
         raise typer.Exit(code=1)
 
-    if expires_unix_timestamp and expires_unix_timestamp < int(datetime.now().timestamp()):
+    if expires_unix_timestamp and expires_unix_timestamp < time.time():
         print("The expiry time you entered is in the past. Please enter a valid expiry time for the PAT.")
         raise typer.Exit(code=1)
 
@@ -156,11 +159,12 @@ def pat_info():
         print("No personal access token stored on this device.")
         return
 
-    if pat_data.pat_expires_at and pat_data.pat_expires_at <= datetime.now().timestamp():
-        print("[red]Warning: this PAT has expired.[/red]")
-
     print(f"Name: {pat_data.name}")
     print(f"Expires: {pat_data.pat_expiry_formatted()}")
+
+    if pat_data.is_pat_expired():
+        print("[red bold]Warning [/red bold]")
+        print(PERSONAL_ACCESS_TOKEN_EXPIRED_MESSAGE)
 
 
 @auth_app.command("whoami")

--- a/packages/divbase-cli/src/divbase_cli/cli_commands/auth_cli.py
+++ b/packages/divbase-cli/src/divbase_cli/cli_commands/auth_cli.py
@@ -89,7 +89,7 @@ def logout():
 @auth_app.command("add-pat")
 def add_pat(
     name: str = typer.Argument(..., help="Name of the personal access token (PAT). E.g. 'work-laptop-pat'"),
-    expires_unix_timestamp: int = typer.Option(
+    expires_unix_timestamp: int | None = typer.Option(
         None,
         "--expires",
         "-e",

--- a/packages/divbase-cli/src/divbase_cli/cli_config.py
+++ b/packages/divbase-cli/src/divbase_cli/cli_config.py
@@ -19,8 +19,9 @@ APP_DIR = Path(typer.get_app_dir(APP_NAME))
 DEFAULT_METADATA_TSV_NAME = "sample_metadata.tsv"
 DEFAULT_LOG_LEVEL = "INFO"
 DEV_MODE = os.getenv("DIVBASE_DEV", "0") == "1"
-CONFIG_PATH = APP_DIR / "config.yaml"
-TOKENS_PATH = APP_DIR / ".secrets"
+DEFAULT_CONFIG_PATH = APP_DIR / "config.yaml"
+DEFAULT_TOKENS_PATH = APP_DIR / ".secrets"
+DEFAULT_PATS_PATH = APP_DIR / ".pat"  # no plural because only 1 stored.
 
 if DEV_MODE:
     DEFAULT_DIVBASE_API_URL = "http://localhost:8000/api"
@@ -39,13 +40,15 @@ class DivBaseCLISettings:
     instead, import the 'cli_settings' instance created at this module's load time.
     """
 
-    CONFIG_PATH: Path = Path(os.getenv("DIVBASE_CLI_CONFIG_PATH", CONFIG_PATH))
+    CONFIG_PATH: Path = Path(os.getenv("DIVBASE_CLI_CONFIG_PATH", DEFAULT_CONFIG_PATH))
 
     # for tokens stored via OS keyring, we use these to define a unique lookup key.
     KEYRING_SERVICE: str = os.getenv("DIVBASE_KEYRING_SERVICE", "divbase-cli")
-    KEYRING_USERNAME: str = "tokens"
-    # Fallback path for tokens storage if keyring cannot be used on device.
-    TOKENS_PATH: Path = Path(os.getenv("DIVBASE_CLI_TOKENS_PATH", TOKENS_PATH))
+    KEYRING_TOKENS_USERNAME: str = "tokens"
+    KEYRING_PATS_USERNAME: str = "pat"
+    # Fallback paths for tokens (JWTs) and PATs storage if keyring cannot be used on the device.
+    TOKENS_FALLBACK_PATH: Path = Path(os.getenv("DIVBASE_CLI_TOKENS_PATH", DEFAULT_TOKENS_PATH))
+    PATS_FALLBACK_PATH: Path = Path(os.getenv("DIVBASE_CLI_PATS_PATH", DEFAULT_PATS_PATH))
 
     DIVBASE_API_URL: str = os.getenv("DIVBASE_API_URL", DEFAULT_DIVBASE_API_URL)
     METADATA_TSV_NAME: str = os.getenv("DIVBASE_METADATA_TSV_NAME", DEFAULT_METADATA_TSV_NAME)

--- a/packages/divbase-cli/src/divbase_cli/config_resolver.py
+++ b/packages/divbase-cli/src/divbase_cli/config_resolver.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from divbase_cli.cli_config import cli_settings
 from divbase_cli.cli_exceptions import AuthenticationError, ProjectNameNotSpecifiedError
+from divbase_cli.user_auth import load_stored_user_pat
 from divbase_cli.user_config import ProjectConfig, load_user_config
 
 
@@ -27,7 +28,7 @@ def ensure_logged_in(desired_url: str | None = None) -> str:
             )
         return config.logged_in_url
 
-    if cli_settings.DIVBASE_API_PAT:
+    if cli_settings.DIVBASE_API_PAT or load_stored_user_pat():
         return desired_url or cli_settings.DIVBASE_API_URL
 
     raise AuthenticationError("You are not logged in. Please log in with 'divbase-cli auth login [EMAIL]'.")
@@ -48,7 +49,7 @@ def resolve_url_for_non_project_specific_commands() -> str:
         return config.logged_in_url
 
     # No active session — fall back to PAT if available.
-    if cli_settings.DIVBASE_API_PAT:
+    if cli_settings.DIVBASE_API_PAT or load_stored_user_pat():
         return cli_settings.DIVBASE_API_URL
 
     raise AuthenticationError("You are not logged in. Please log in with 'divbase-cli auth login [EMAIL]'.")

--- a/packages/divbase-cli/src/divbase_cli/config_resolver.py
+++ b/packages/divbase-cli/src/divbase_cli/config_resolver.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from divbase_cli.cli_config import cli_settings
 from divbase_cli.cli_exceptions import AuthenticationError, ProjectNameNotSpecifiedError
-from divbase_cli.user_auth import load_stored_user_pat
+from divbase_cli.user_auth import get_pat_for_authentication
 from divbase_cli.user_config import ProjectConfig, load_user_config
 
 
@@ -28,7 +28,7 @@ def ensure_logged_in(desired_url: str | None = None) -> str:
             )
         return config.logged_in_url
 
-    if cli_settings.DIVBASE_API_PAT or load_stored_user_pat():
+    if get_pat_for_authentication():
         return desired_url or cli_settings.DIVBASE_API_URL
 
     raise AuthenticationError("You are not logged in. Please log in with 'divbase-cli auth login [EMAIL]'.")
@@ -48,8 +48,7 @@ def resolve_url_for_non_project_specific_commands() -> str:
     if config.logged_in_url:
         return config.logged_in_url
 
-    # No active session — fall back to PAT if available.
-    if cli_settings.DIVBASE_API_PAT or load_stored_user_pat():
+    if get_pat_for_authentication():
         return cli_settings.DIVBASE_API_URL
 
     raise AuthenticationError("You are not logged in. Please log in with 'divbase-cli auth login [EMAIL]'.")

--- a/packages/divbase-cli/src/divbase_cli/user_auth.py
+++ b/packages/divbase-cli/src/divbase_cli/user_auth.py
@@ -3,8 +3,12 @@ Manage user authentication with the DivBase server.
 
 This includes login/logout and the getting, storing, using, and refreshing of access + refresh JWTs and Personal Access Tokens (PATs).
 
-User JWTs are stored in the device's OS keyring. They fallback to a local file with 0600 permissions if not possible.
-PATs provided via environment variable
+User JWTs and PATs can be stored in the device's OS keyring.
+They fallback to a local file with 0600 permissions if not possible.
+- JWTs stored on login
+- PATs stored when user adds one via the add-pat CLI command.
+
+PATs can also be provided via environment variable (which takes precedence over any stored PATs) but no over a logged in session.
 """
 
 import contextlib
@@ -14,6 +18,7 @@ import os
 import time
 import warnings
 from dataclasses import dataclass
+from datetime import datetime
 from json import JSONDecodeError
 from pathlib import Path
 
@@ -46,7 +51,7 @@ class TokenData:
     access_token_expires_at: int
     refresh_token_expires_at: int
 
-    def dump_tokens(self, output_path: Path = cli_settings.TOKENS_PATH) -> None:
+    def dump_tokens(self, fallback_output_path: Path = cli_settings.TOKENS_FALLBACK_PATH) -> None:
         """Dump the user token data to the OS keyring. If fails, fall back to a local file."""
         token_dict = {
             "access_token": self.access_token.get_secret_value(),
@@ -57,20 +62,20 @@ class TokenData:
         try:
             keyring.set_password(
                 service_name=cli_settings.KEYRING_SERVICE,
-                username=cli_settings.KEYRING_USERNAME,
+                username=cli_settings.KEYRING_TOKENS_USERNAME,
                 password=json.dumps(token_dict),
             )
-            output_path.unlink(missing_ok=True)
+            fallback_output_path.unlink(missing_ok=True)
             logger.debug("JWTs stored in device keyring successfully.")
             return
         except KeyringError as e:
             logger.debug(f"Keyring JWT storage failed with error: {e}\n falling back to file storage.")
 
-        output_path.parent.mkdir(parents=True, exist_ok=True)
+        fallback_output_path.parent.mkdir(parents=True, exist_ok=True)
         # Create file with 0600 permissions (user read/write only).
         # Windows doesn't support 0600 permissions, but Windows can use keyring, so should never reach this fallback.
         # Even if a Windows OS can't use keyring the fallback will still work, the 0600 mode will just be ignored.
-        fd = os.open(path=output_path, flags=os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode=0o600)
+        fd = os.open(path=fallback_output_path, flags=os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode=0o600)
         with os.fdopen(fd, "w") as file:
             yaml.safe_dump(token_dict, file, sort_keys=False)
 
@@ -86,8 +91,60 @@ class TokenData:
 def _delete_stored_jwts(token_path: Path) -> None:
     """Attempt to delete user JWTs from both the keyring and the fallback file."""
     with contextlib.suppress(KeyringError):
-        keyring.delete_password(service_name=cli_settings.KEYRING_SERVICE, username=cli_settings.KEYRING_USERNAME)
+        keyring.delete_password(
+            service_name=cli_settings.KEYRING_SERVICE, username=cli_settings.KEYRING_TOKENS_USERNAME
+        )
     token_path.unlink(missing_ok=True)
+
+
+@dataclass
+class PATData:
+    """Class to hold user PAT data"""
+
+    name: str
+    pat_expires_at: int | None  # None means the PAT does not expire
+    pat: SecretStr
+
+    def dump_pat_data(self, fallback_output_path: Path = cli_settings.PATS_FALLBACK_PATH) -> None:
+        """Dump the user PAT data to the OS keyring. If fails, fall back to a local file."""
+        token_dict = {
+            "name": self.name,
+            "pat_expires_at": self.pat_expires_at,
+            "pat": self.pat.get_secret_value(),
+        }
+        try:
+            keyring.set_password(
+                service_name=cli_settings.KEYRING_SERVICE,
+                username=cli_settings.KEYRING_PATS_USERNAME,
+                password=json.dumps(token_dict),
+            )
+            fallback_output_path.unlink(missing_ok=True)
+            logger.debug("PATs stored in device keyring successfully.")
+            return
+        except KeyringError as e:
+            logger.debug(f"Keyring PAT storage failed with error: {e}\n falling back to file storage.")
+
+        fallback_output_path.parent.mkdir(parents=True, exist_ok=True)
+        # Create file with 0600 permissions (user read/write only).
+        # Windows doesn't support 0600 permissions, but Windows can use keyring, so should never reach this fallback.
+        # Even if a Windows OS can't use keyring the fallback will still work, the 0600 mode will just be ignored.
+        fd = os.open(path=fallback_output_path, flags=os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode=0o600)
+        with os.fdopen(fd, "w") as file:
+            yaml.safe_dump(token_dict, file, sort_keys=False)
+
+    def pat_expiry_formatted(self) -> str:
+        """Returns the token's expiry time in a human readable format in user's current timezone."""
+        if self.pat_expires_at is None:
+            return "Never"
+        expiry = datetime.fromtimestamp(self.pat_expires_at).astimezone()
+        return expiry.strftime("%Y-%m-%d %H:%M:%S %Z")
+
+
+def delete_stored_pat(pat_path: Path = cli_settings.PATS_FALLBACK_PATH) -> None:
+    """Attempt to delete user PAT from both the keyring and the fallback file."""
+    with contextlib.suppress(KeyringError):
+        keyring.delete_password(service_name=cli_settings.KEYRING_SERVICE, username=cli_settings.KEYRING_PATS_USERNAME)
+    pat_path.unlink(missing_ok=True)
 
 
 def check_existing_session(divbase_url: str, config) -> int | None:
@@ -172,7 +229,7 @@ def login_to_divbase(email: str, password: SecretStr, divbase_url: str) -> None:
     config.set_login_status(url=divbase_url, email=email)
 
 
-def logout_of_divbase(token_path: Path = cli_settings.TOKENS_PATH) -> None:
+def logout_of_divbase(token_path: Path = cli_settings.TOKENS_FALLBACK_PATH) -> None:
     """
     Log out of the DivBase server.
     We send the refresh token to DivBase to be revoked server-side.
@@ -219,13 +276,15 @@ def logout_of_divbase(token_path: Path = cli_settings.TOKENS_PATH) -> None:
     config.set_login_status(url=None, email=None)
 
 
-def load_user_tokens(token_path: Path = cli_settings.TOKENS_PATH) -> TokenData | None:
+def load_user_tokens(token_path: Path = cli_settings.TOKENS_FALLBACK_PATH) -> TokenData | None:
     """
     Load user tokens from the OS keyring. Fallback for this is a local file with 0600 permissions.
     Return None if no tokens found or if tokens are malformed/invalid - user logged out.
     """
     try:
-        raw = keyring.get_password(service_name=cli_settings.KEYRING_SERVICE, username=cli_settings.KEYRING_USERNAME)
+        raw = keyring.get_password(
+            service_name=cli_settings.KEYRING_SERVICE, username=cli_settings.KEYRING_TOKENS_USERNAME
+        )
     except KeyringError as e:
         raw = None
         logger.debug(f"Keyring read failed with error: {e}, falling back to file storage.")
@@ -262,12 +321,87 @@ def load_user_tokens(token_path: Path = cli_settings.TOKENS_PATH) -> TokenData |
     return token_data
 
 
+def load_stored_user_pat(pat_fallback_path: Path = cli_settings.PATS_FALLBACK_PATH) -> PATData | None:
+    """
+    Attempts to load a user's Personal Access Token (PAT) from:
+    1. OS keyring (if stored there)
+    2. file fallback (if stored there)
+
+    Returns the PATData if found and valid, else None.
+    """
+    try:
+        raw = keyring.get_password(
+            service_name=cli_settings.KEYRING_SERVICE, username=cli_settings.KEYRING_PATS_USERNAME
+        )
+    except KeyringError as e:
+        raw = None
+        logger.debug(f"Keyring read failed with error: {e}, falling back to file storage.")
+
+    if raw is not None:
+        try:
+            pat_dict = json.loads(raw)
+            return PATData(
+                name=pat_dict["name"],
+                pat=SecretStr(pat_dict["pat"]),
+                pat_expires_at=pat_dict["pat_expires_at"],
+            )
+        except (KeyError, json.JSONDecodeError) as e:
+            logger.debug(f"Keyring PAT data malformed: {e}")
+
+    if not pat_fallback_path.exists():
+        return None
+
+    with open(pat_fallback_path, "r") as file:
+        pat_dict = yaml.safe_load(file)
+
+    try:
+        pat_data = PATData(
+            name=pat_dict["name"],
+            pat=SecretStr(pat_dict["pat"]),
+            pat_expires_at=pat_dict["pat_expires_at"],
+        )
+    except KeyError as e:
+        logger.debug(f"User PAT file at {pat_fallback_path} appears to be malformed: {e}")
+        return None
+
+    return pat_data
+
+
+def get_pat_for_authentication() -> SecretStr | None:
+    """
+    Get a user's Personal Access Token (PAT) for authentication with the DivBase API.
+
+    Priority order:
+    1. Environment variable
+    2. OS keyring
+    3. file with 0600 permissions fallback
+
+    Returns the PAT as a SecretStr if found and valid, else None.
+    """
+    pat = cli_settings.DIVBASE_API_PAT
+    if pat is not None:
+        return pat
+    pat_data = load_stored_user_pat()
+
+    if not pat_data:
+        return None
+
+    if pat_data.pat_expires_at and pat_data.pat_expires_at <= time.time():
+        raise AuthenticationError(
+            "Your Personal Access Token (PAT) has expired. \n"
+            "Please create a new one and add it with 'divbase-cli auth add-pat'. \n"
+            "See https://scilifelabdatacentre.github.io/divbase/user-guides/account-management/#personal-access-tokens for more details."
+        )
+
+    return pat_data.pat
+
+
 @stamina.retry(on=retry_only_on_retryable_divbase_api_errors, attempts=3)
 def make_authenticated_request(
     method: str,
     divbase_base_url: str,
     api_route: str,
-    token_path: Path = cli_settings.TOKENS_PATH,
+    token_path: Path = cli_settings.TOKENS_FALLBACK_PATH,
     **kwargs,
 ) -> httpx.Response:
     """Make an authenticated request to the DivBase server, handles refreshing tokens if needed."""
@@ -276,10 +410,11 @@ def make_authenticated_request(
 
     token_data = load_user_tokens(token_path=token_path)
     if not token_data:
-        if not cli_settings.DIVBASE_API_PAT:
+        pat = get_pat_for_authentication()
+        if not pat:
             raise AuthenticationError(LOGIN_AGAIN_MESSAGE)
         logger.info("Using personal access token in request to DivBase API.")
-        headers["Authorization"] = f"Bearer {cli_settings.DIVBASE_API_PAT.get_secret_value()}"
+        headers["Authorization"] = f"Bearer {pat.get_secret_value()}"
     else:
         if token_data.is_access_token_expired():
             if token_data.is_refresh_token_expired():
@@ -365,7 +500,7 @@ def _refresh_access_token(token_data: TokenData, divbase_base_url: str) -> Token
             # Prevents user getting warning about being already logged in when they try to log in again.
             config = load_user_config()
             config.set_login_status(url=None, email=None)
-            _delete_stored_jwts(token_path=cli_settings.TOKENS_PATH)
+            _delete_stored_jwts(token_path=cli_settings.TOKENS_FALLBACK_PATH)
             raise AuthenticationError(LOGIN_AGAIN_MESSAGE) from None
 
         _handle_divbase_api_error(response=response, http_method="POST", url=refresh_url)

--- a/packages/divbase-cli/src/divbase_cli/user_auth.py
+++ b/packages/divbase-cli/src/divbase_cli/user_auth.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from json import JSONDecodeError
 from pathlib import Path
+from typing import Any
 
 import httpx
 import keyring
@@ -38,6 +39,12 @@ from divbase_lib.api_schemas.auth import LogoutRequest
 from divbase_lib.divbase_constants import CLI_VERSION_HEADER_KEY
 
 LOGIN_AGAIN_MESSAGE = "Your session has expired. Please log in again with 'divbase-cli auth login [EMAIL]'."
+PERSONAL_ACCESS_TOKEN_EXPIRED_MESSAGE = (
+    "Your Personal Access Token (PAT) has expired. \n"
+    "Please create a new one and add it with 'divbase-cli auth add-pat'. \n"
+    "See https://scilifelabdatacentre.github.io/divbase/user-guides/account-management/#personal-access-tokens for more details."
+)
+
 
 logger = logging.getLogger(__name__)
 
@@ -59,25 +66,11 @@ class TokenData:
             "access_token_expires_at": self.access_token_expires_at,
             "refresh_token_expires_at": self.refresh_token_expires_at,
         }
-        try:
-            keyring.set_password(
-                service_name=cli_settings.KEYRING_SERVICE,
-                username=cli_settings.KEYRING_TOKENS_USERNAME,
-                password=json.dumps(token_dict),
-            )
-            fallback_output_path.unlink(missing_ok=True)
-            logger.debug("JWTs stored in device keyring successfully.")
-            return
-        except KeyringError as e:
-            logger.debug(f"Keyring JWT storage failed with error: {e}\n falling back to file storage.")
-
-        fallback_output_path.parent.mkdir(parents=True, exist_ok=True)
-        # Create file with 0600 permissions (user read/write only).
-        # Windows doesn't support 0600 permissions, but Windows can use keyring, so should never reach this fallback.
-        # Even if a Windows OS can't use keyring the fallback will still work, the 0600 mode will just be ignored.
-        fd = os.open(path=fallback_output_path, flags=os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode=0o600)
-        with os.fdopen(fd, "w") as file:
-            yaml.safe_dump(token_dict, file, sort_keys=False)
+        _dump_to_keyring_or_file(
+            data=token_dict,
+            keyring_user_name=cli_settings.KEYRING_TOKENS_USERNAME,
+            fallback_file_path=fallback_output_path,
+        )
 
     def is_access_token_expired(self) -> bool:
         """Check if the access token is expired"""
@@ -112,25 +105,16 @@ class PATData:
             "pat_expires_at": self.pat_expires_at,
             "pat": self.pat.get_secret_value(),
         }
-        try:
-            keyring.set_password(
-                service_name=cli_settings.KEYRING_SERVICE,
-                username=cli_settings.KEYRING_PATS_USERNAME,
-                password=json.dumps(token_dict),
-            )
-            fallback_output_path.unlink(missing_ok=True)
-            logger.debug("PATs stored in device keyring successfully.")
-            return
-        except KeyringError as e:
-            logger.debug(f"Keyring PAT storage failed with error: {e}\n falling back to file storage.")
+        _dump_to_keyring_or_file(
+            data=token_dict,
+            keyring_user_name=cli_settings.KEYRING_PATS_USERNAME,
+            fallback_file_path=fallback_output_path,
+        )
 
-        fallback_output_path.parent.mkdir(parents=True, exist_ok=True)
-        # Create file with 0600 permissions (user read/write only).
-        # Windows doesn't support 0600 permissions, but Windows can use keyring, so should never reach this fallback.
-        # Even if a Windows OS can't use keyring the fallback will still work, the 0600 mode will just be ignored.
-        fd = os.open(path=fallback_output_path, flags=os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode=0o600)
-        with os.fdopen(fd, "w") as file:
-            yaml.safe_dump(token_dict, file, sort_keys=False)
+    def is_pat_expired(self) -> bool:
+        """Check if the PAT is expired"""
+        cutoff = time.time() + 10  # 10 second buffer to account for clock skew or time delay
+        return self.pat_expires_at is not None and self.pat_expires_at <= cutoff
 
     def pat_expiry_formatted(self) -> str:
         """Returns the token's expiry time in a human readable format in user's current timezone."""
@@ -314,7 +298,7 @@ def load_user_tokens(token_path: Path = cli_settings.TOKENS_FALLBACK_PATH) -> To
             access_token_expires_at=token_dict["access_token_expires_at"],
             refresh_token_expires_at=token_dict["refresh_token_expires_at"],
         )
-    except KeyError as e:
+    except (KeyError, TypeError) as e:
         logger.debug(f"User tokens file at {token_path} appears to be malformed: {e}")
         return None
 
@@ -360,7 +344,7 @@ def load_stored_user_pat(pat_fallback_path: Path = cli_settings.PATS_FALLBACK_PA
             pat=SecretStr(pat_dict["pat"]),
             pat_expires_at=pat_dict["pat_expires_at"],
         )
-    except KeyError as e:
+    except (KeyError, TypeError) as e:
         logger.debug(f"User PAT file at {pat_fallback_path} appears to be malformed: {e}")
         return None
 
@@ -386,12 +370,8 @@ def get_pat_for_authentication() -> SecretStr | None:
     if not pat_data:
         return None
 
-    if pat_data.pat_expires_at and pat_data.pat_expires_at <= time.time():
-        raise AuthenticationError(
-            "Your Personal Access Token (PAT) has expired. \n"
-            "Please create a new one and add it with 'divbase-cli auth add-pat'. \n"
-            "See https://scilifelabdatacentre.github.io/divbase/user-guides/account-management/#personal-access-tokens for more details."
-        )
+    if pat_data.is_pat_expired():
+        raise AuthenticationError(PERSONAL_ACCESS_TOKEN_EXPIRED_MESSAGE)
 
     return pat_data.pat
 
@@ -515,3 +495,31 @@ def _refresh_access_token(token_data: TokenData, divbase_base_url: str) -> Token
     )
     new_token_data.dump_tokens()
     return new_token_data
+
+
+def _dump_to_keyring_or_file(data: dict[Any, Any], keyring_user_name: str, fallback_file_path: Path) -> None:
+    """
+    Helper fn to dump a dict to user's OS keyring.
+
+    If dump fails, will fallback to a local file and set permissions to 0600 (user read/write only).
+    Used to store both JWTs and PATs.
+    """
+    try:
+        keyring.set_password(
+            service_name=cli_settings.KEYRING_SERVICE,
+            username=keyring_user_name,
+            password=json.dumps(data),
+        )
+        fallback_file_path.unlink(missing_ok=True)
+        logger.debug(f"Data stored in user device keyring under username: {keyring_user_name}")
+        return
+    except KeyringError as e:
+        logger.debug(f"Keyring storage failed with error: {e}\n falling back to file storage.")
+
+    fallback_file_path.parent.mkdir(parents=True, exist_ok=True)
+    # Create file with 0600 permissions (user read/write only).
+    # Windows doesn't support 0600 permissions, but Windows can use keyring, so should never reach this fallback.
+    # Even if a Windows OS can't use keyring the fallback will still work, the 0600 mode will just be ignored.
+    fd = os.open(path=fallback_file_path, flags=os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode=0o600)
+    with os.fdopen(fd, "w") as file:
+        yaml.safe_dump(data, file, sort_keys=False)

--- a/packages/divbase-cli/src/divbase_cli/user_auth.py
+++ b/packages/divbase-cli/src/divbase_cli/user_auth.py
@@ -8,7 +8,7 @@ They fallback to a local file with 0600 permissions if not possible.
 - JWTs stored on login
 - PATs stored when user adds one via the add-pat CLI command.
 
-PATs can also be provided via environment variable (which takes precedence over any stored PATs) but no over a logged in session.
+PATs can also be provided via environment variable (which takes precedence over any stored PATs) but not over a logged in session.
 """
 
 import contextlib

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,6 +11,7 @@ env =
     # divbase-cli test settings
     DIVBASE_CLI_CONFIG_PATH=tests/fixtures/tmp/config.yaml
     DIVBASE_CLI_TOKENS_PATH=tests/fixtures/tmp/.fakesecrets
+    DIVBASE_CLI_PATS_PATH=tests/fixtures/tmp/.fakepat
     DIVBASE_KEYRING_SERVICE=divbase-cli-test
     DIVBASE_API_URL=http://localhost:8001/api
     # API and worker test settings (used in unit tests - as integration/e2e get the settings from docker-compose)

--- a/tests/e2e_integration/cli_commands/conftest.py
+++ b/tests/e2e_integration/cli_commands/conftest.py
@@ -110,8 +110,15 @@ def _create_logged_in_user_fixture(user_type: str):
         cli_settings.CONFIG_PATH.unlink(missing_ok=True)
         # tokens can either be stored in device keyring (or in a fallback file if e.g. keyring not available - likely for CI or disabled for a test)
         with contextlib.suppress(KeyringError):
-            keyring.delete_password(service_name=cli_settings.KEYRING_SERVICE, username=cli_settings.KEYRING_USERNAME)
-        cli_settings.TOKENS_PATH.unlink(missing_ok=True)
+            keyring.delete_password(
+                service_name=cli_settings.KEYRING_SERVICE, username=cli_settings.KEYRING_TOKENS_USERNAME
+            )
+        cli_settings.TOKENS_FALLBACK_PATH.unlink(missing_ok=True)
+        with contextlib.suppress(KeyringError):
+            keyring.delete_password(
+                service_name=cli_settings.KEYRING_SERVICE, username=cli_settings.KEYRING_PATS_USERNAME
+            )
+        cli_settings.PATS_FALLBACK_PATH.unlink(missing_ok=True)
 
         # running any cmd that requires the config file will create it
         for project in CONSTANTS["PROJECT_TO_BUCKET_MAP"]:
@@ -139,7 +146,14 @@ def _create_logged_in_user_fixture(user_type: str):
         cli_settings.CONFIG_PATH.unlink(missing_ok=True)
         # tokens can either be stored in device keyring (or in a fallback file if e.g. keyring not available - likely for CI or disabled for a test)
         with contextlib.suppress(KeyringError):
-            keyring.delete_password(service_name=cli_settings.KEYRING_SERVICE, username=cli_settings.KEYRING_USERNAME)
-        cli_settings.TOKENS_PATH.unlink(missing_ok=True)
+            keyring.delete_password(
+                service_name=cli_settings.KEYRING_SERVICE, username=cli_settings.KEYRING_TOKENS_USERNAME
+            )
+        cli_settings.TOKENS_FALLBACK_PATH.unlink(missing_ok=True)
+        with contextlib.suppress(KeyringError):
+            keyring.delete_password(
+                service_name=cli_settings.KEYRING_SERVICE, username=cli_settings.KEYRING_PATS_USERNAME
+            )
+        cli_settings.PATS_FALLBACK_PATH.unlink(missing_ok=True)
 
     return factory

--- a/tests/e2e_integration/cli_commands/test_auth_cli.py
+++ b/tests/e2e_integration/cli_commands/test_auth_cli.py
@@ -3,9 +3,11 @@ E2E tests for the "divbase-cli auth" CLI commands.
 """
 
 import shutil
+from datetime import datetime, timedelta
 
 import keyring
 import pytest
+from click.testing import Result
 from keyring.errors import NoKeyringError
 from pydantic import SecretStr
 from typer.testing import CliRunner
@@ -39,9 +41,9 @@ def make_tokens_expired(access: bool = False, refresh: bool = False):
     Helper function to make either the access token or refresh token expired in the tokens file.
     Sets the expiry time to 1970 (unix time stamp)
     """
-    with open(cli_settings.TOKENS_PATH, "r") as token_file:
+    with open(cli_settings.TOKENS_FALLBACK_PATH, "r") as token_file:
         lines = token_file.readlines()
-    with open(cli_settings.TOKENS_PATH, "w") as token_file:
+    with open(cli_settings.TOKENS_FALLBACK_PATH, "w") as token_file:
         for line in lines:
             if access and line.startswith("access_token_expires_at:"):
                 token_file.write("access_token_expires_at: 1\n")
@@ -220,12 +222,12 @@ def test_using_revoked_refresh_token_fails(tmp_path, disable_keyring_backend):
     log_in_as_user()
 
     shutil.copy(cli_settings.CONFIG_PATH, tmp_path / "config_backup.yaml")
-    shutil.copy(cli_settings.TOKENS_PATH, tmp_path / "tokens_backup.yaml")
+    shutil.copy(cli_settings.TOKENS_FALLBACK_PATH, tmp_path / "tokens_backup.yaml")
 
     result = runner.invoke(app=app, args=logout_command)
     assert result.exit_code == 0
 
-    shutil.copy(tmp_path / "tokens_backup.yaml", cli_settings.TOKENS_PATH)
+    shutil.copy(tmp_path / "tokens_backup.yaml", cli_settings.TOKENS_FALLBACK_PATH)
     shutil.copy(tmp_path / "config_backup.yaml", cli_settings.CONFIG_PATH)
     make_tokens_expired(access=True)
 
@@ -282,3 +284,121 @@ def test_jwt_session_takes_priority_over_pat(disable_keyring_backend, monkeypatc
     result = runner.invoke(app=app, args="auth whoami")
     assert result.exit_code == 0
     assert USER_EMAIL in result.stdout
+
+
+_FAKE_PAT_NAME = "work-laptop"
+_FAKE_PAT = "divbase_pat_fakefakefakefakefakefakefake"
+
+
+def run_add_pat_cmd(
+    name: str = _FAKE_PAT_NAME,
+    expires: int | None = 9999999999,
+    pat: str = _FAKE_PAT,
+    overwrite: bool = False,
+) -> Result:
+    """Helper fn to run the add-pat command."""
+    args = f"auth add-pat {name}"
+    if expires is not None:
+        args += f" --expires {expires}"
+    if overwrite:
+        args += " --overwrite-existing"
+    return runner.invoke(
+        app=app,
+        args=args,
+        input=f"{pat}\n",
+    )
+
+
+@pytest.fixture
+def cleanup_stored_cli_pat():
+    """Remove any possibly stored PAT from a add-pat command in a test"""
+    yield
+    # rm-pat is idempotent, so doesn't matter if there is no PAT.
+    result = runner.invoke(app=app, args="auth rm-pat")
+    assert result.exit_code == 0
+
+
+def test_add_pat_stores_pat(cleanup_stored_cli_pat):
+    """add-pat should store the PAT and pat-info should now show the PATs is stored"""
+    result = run_add_pat_cmd()
+    assert result.exit_code == 0
+    assert _FAKE_PAT_NAME in result.stdout
+
+    info = runner.invoke(app=app, args="auth pat-info")
+    assert info.exit_code == 0
+    assert _FAKE_PAT_NAME in info.stdout
+    assert _FAKE_PAT not in info.stdout  # PAT should not be printed
+
+
+def test_add_pat_rejects_invalid_pat_prefix(cleanup_stored_cli_pat):
+    """add-pat should fail if the token doesn't start with the PAT prefix."""
+    result = run_add_pat_cmd(pat="not_a_real_pat")
+    assert result.exit_code != 0
+    assert "not a valid personal access token" in result.stdout
+
+
+def test_add_pat_rejects_already_expired_pat(cleanup_stored_cli_pat):
+    """add-pat should fail if the token doesn't start with the PAT prefix."""
+    one_day_ago = datetime.now() - timedelta(days=1)
+    result = run_add_pat_cmd(expires=int(one_day_ago.timestamp()))
+    assert result.exit_code != 0
+    assert "expiry" in result.stdout
+
+
+def test_add_pat_with_no_expiry(cleanup_stored_cli_pat):
+    """add-pat without --expires set works and stores a PAT."""
+    result = run_add_pat_cmd(expires=None)
+    assert result.exit_code == 0
+    assert _FAKE_PAT_NAME in result.stdout
+
+    info = runner.invoke(app=app, args="auth pat-info")
+    assert info.exit_code == 0
+    assert _FAKE_PAT_NAME in info.stdout
+    assert "Never" in info.stdout  # expiry info
+    assert _FAKE_PAT not in info.stdout  # PAT should not be printed
+
+
+def test_cannot_add_pat_without_overwrite_flag(cleanup_stored_cli_pat):
+    """add-pat must refuse to overwrite an existing PAT unless --overwrite-existing is passed."""
+    result = run_add_pat_cmd()
+    assert result.exit_code == 0
+    assert _FAKE_PAT_NAME in result.stdout
+
+    result = run_add_pat_cmd()
+    assert result.exit_code != 0
+    assert "already stored" in result.stdout
+    assert "--overwrite-existing" in result.stdout
+
+    result = run_add_pat_cmd(overwrite=True)
+    assert result.exit_code == 0
+    assert _FAKE_PAT_NAME in result.stdout
+
+    result = run_add_pat_cmd(name="a-new-pat", overwrite=True)
+    assert result.exit_code == 0
+    assert "a-new-pat" in result.stdout
+
+
+def test_rm_pat_removes_stored_pat(cleanup_stored_cli_pat):
+    """rm-pat should remove the stored PAT so that pat-info shows nothing."""
+    result = run_add_pat_cmd()
+    assert result.exit_code == 0
+
+    result = runner.invoke(app=app, args="auth rm-pat")
+    assert result.exit_code == 0
+
+    info = runner.invoke(app=app, args="auth pat-info")
+    assert info.exit_code == 0
+    assert "No personal access token" in info.stdout
+
+
+def test_rm_pat_with_no_pat_is_ok(cleanup_stored_cli_pat):
+    """rm-pat should succeed even if no PAT is currently stored."""
+    result = runner.invoke(app=app, args="auth rm-pat")
+    assert result.exit_code == 0
+
+
+def test_pat_info_when_no_pat_stored(cleanup_stored_cli_pat):
+    """pat-info should report nothing stored when no PAT has been added."""
+    info = runner.invoke(app=app, args="auth pat-info")
+    assert info.exit_code == 0
+    assert "No personal access token" in info.stdout

--- a/tests/e2e_integration/cli_commands/test_auth_cli.py
+++ b/tests/e2e_integration/cli_commands/test_auth_cli.py
@@ -16,6 +16,7 @@ from divbase_cli.cli_config import cli_settings
 from divbase_cli.cli_exceptions import AuthenticationError, DivBaseAPIConnectionError, DivBaseAPIError
 from divbase_cli.divbase_cli import app
 from divbase_cli.user_auth import LOGIN_AGAIN_MESSAGE
+from divbase_lib.divbase_constants import PAT_TOKEN_PREFIX
 
 runner = CliRunner()
 
@@ -279,7 +280,7 @@ def test_jwt_session_takes_priority_over_pat(disable_keyring_backend, monkeypatc
     """
     log_in_as_user()
 
-    monkeypatch.setattr(cli_settings, "DIVBASE_API_PAT", SecretStr("divbase_pat_fake_not_a_real_token"))
+    monkeypatch.setattr(cli_settings, "DIVBASE_API_PAT", SecretStr(f"{PAT_TOKEN_PREFIX}_fake_not_a_real_token"))
 
     result = runner.invoke(app=app, args="auth whoami")
     assert result.exit_code == 0
@@ -287,7 +288,7 @@ def test_jwt_session_takes_priority_over_pat(disable_keyring_backend, monkeypatc
 
 
 _FAKE_PAT_NAME = "work-laptop"
-_FAKE_PAT = "divbase_pat_fakefakefakefakefakefakefake"
+_FAKE_PAT = f"{PAT_TOKEN_PREFIX}_fakefakefakefakefakefakefake"
 
 
 def run_add_pat_cmd(

--- a/tests/e2e_integration/cli_commands/test_personal_access_tokens.py
+++ b/tests/e2e_integration/cli_commands/test_personal_access_tokens.py
@@ -9,6 +9,14 @@ Almost all API endpoints are scoped based on project level permissions which is 
 get_project_member in deps.py. Other more special cases like auth whoami and task-history user have their logic.
 
 So below we cover a representative cmd for project scope (files ls) and then the special cases.
+
+### Why mostly just env var tests
+A user can provide a PAT via an env var or from storing it with the add-pat command.
+
+Logic to validate those cli cmds is in test_auth_cli.py.
+
+We have 1 e2e test here that covers using the PAT stored by the add-pat command, otherwise we use the env var approach for convienance.
+These tests primarly focus on PATs being scoped correctly etc...
 """
 
 from datetime import datetime, timedelta, timezone
@@ -264,11 +272,32 @@ def test_expired_pat_rejected(CONSTANTS, logged_out_user_with_existing_config, p
     assert_401_error(result)
 
 
-def test_pat_does_not_work_on_frontend_endpoints(
-    CONSTANTS, logged_out_user_with_existing_config, pat_factory, monkeypatch
-):
+def test_pat_stored_via_add_pat_cmd_works(CONSTANTS, logged_out_user_with_existing_config, pat_factory):
+    """Validate that a PAT stored via the add-pat cmd works for authentication and respects scopes."""
+    raw_token: SecretStr = pat_factory(user_email=EDIT_USER_EMAIL, permissions=NO_SCOPE_PERMISSIONS)
+    try:
+        result = runner.invoke(
+            app=app,
+            args="auth add-pat my-pat",
+            input=f"{raw_token.get_secret_value()}\n",
+        )
+        assert result.exit_code == 0
+
+        result = runner.invoke(app, "auth whoami")
+        assert result.exit_code == 0
+        assert EDIT_USER_EMAIL in result.output
+
+        result = runner.invoke(app, f"files ls --project {CONSTANTS['DEFAULT_PROJECT']}")
+        assert_403_error(result)
+    finally:
+        # clean up the stored PAT so it doesn't interfere with other tests, even if above fails
+        result = runner.invoke(app=app, args="auth rm-pat")
+        assert result.exit_code == 0
+
+
+def test_pat_does_not_work_on_frontend_endpoints(CONSTANTS, logged_out_user_with_existing_config, pat_factory):
     """PATs should not work on frontend endpoints"""
-    raw_token = pat_factory(user_email=EDIT_USER_EMAIL, permissions=FULL_ACCESS_PAT_PERMISSIONS)
+    raw_token: SecretStr = pat_factory(user_email=EDIT_USER_EMAIL, permissions=FULL_ACCESS_PAT_PERMISSIONS)
 
     home_url = "http://localhost:8001/"
     # technically don't need the token here

--- a/tests/e2e_integration/cli_commands/test_personal_access_tokens.py
+++ b/tests/e2e_integration/cli_commands/test_personal_access_tokens.py
@@ -15,8 +15,8 @@ A user can provide a PAT via an env var or from storing it with the add-pat comm
 
 Logic to validate those cli cmds is in test_auth_cli.py.
 
-We have 1 e2e test here that covers using the PAT stored by the add-pat command, otherwise we use the env var approach for convienance.
-These tests primarly focus on PATs being scoped correctly etc...
+We have 1 e2e test here that covers using the PAT stored by the add-pat command, otherwise we use the env var approach for convenience.
+These tests primarily focus on PATs being scoped correctly etc...
 """
 
 from datetime import datetime, timedelta, timezone

--- a/tests/e2e_integration/conftest.py
+++ b/tests/e2e_integration/conftest.py
@@ -52,16 +52,26 @@ def clean_tmp_config_and_tokens_between_tests():
     cli_settings.CONFIG_PATH.unlink(missing_ok=True)
     # tokens can either be stored in device keyring (or in a fallback file if e.g. keyring not available - likely for CI or disabled for a test)
     with contextlib.suppress(KeyringError):
-        keyring.delete_password(service_name=cli_settings.KEYRING_SERVICE, username=cli_settings.KEYRING_USERNAME)
-    cli_settings.TOKENS_PATH.unlink(missing_ok=True)
+        keyring.delete_password(
+            service_name=cli_settings.KEYRING_SERVICE, username=cli_settings.KEYRING_TOKENS_USERNAME
+        )
+    cli_settings.TOKENS_FALLBACK_PATH.unlink(missing_ok=True)
+    with contextlib.suppress(KeyringError):
+        keyring.delete_password(service_name=cli_settings.KEYRING_SERVICE, username=cli_settings.KEYRING_PATS_USERNAME)
+    cli_settings.PATS_FALLBACK_PATH.unlink(missing_ok=True)
 
     yield
 
     cli_settings.CONFIG_PATH.unlink(missing_ok=True)
     # tokens can either be stored in device keyring (or in a fallback file if e.g. keyring not available - likely for CI or disabled for a test)
     with contextlib.suppress(KeyringError):
-        keyring.delete_password(service_name=cli_settings.KEYRING_SERVICE, username=cli_settings.KEYRING_USERNAME)
-    cli_settings.TOKENS_PATH.unlink(missing_ok=True)
+        keyring.delete_password(
+            service_name=cli_settings.KEYRING_SERVICE, username=cli_settings.KEYRING_TOKENS_USERNAME
+        )
+    cli_settings.TOKENS_FALLBACK_PATH.unlink(missing_ok=True)
+    with contextlib.suppress(KeyringError):
+        keyring.delete_password(service_name=cli_settings.KEYRING_SERVICE, username=cli_settings.KEYRING_PATS_USERNAME)
+    cli_settings.PATS_FALLBACK_PATH.unlink(missing_ok=True)
 
 
 @pytest.fixture(scope="session")
@@ -268,7 +278,7 @@ def logged_in_edit_user_with_existing_config(CONSTANTS):
     """Shared fixture: logged-in edit user with existing CLI config."""
     # ensure no config or tokens file exist before test
     cli_settings.CONFIG_PATH.unlink(missing_ok=True)
-    cli_settings.TOKENS_PATH.unlink(missing_ok=True)
+    cli_settings.TOKENS_FALLBACK_PATH.unlink(missing_ok=True)
 
     for project in CONSTANTS["PROJECT_TO_BUCKET_MAP"]:
         add_command = f"config add {project}"
@@ -287,7 +297,7 @@ def logged_in_edit_user_with_existing_config(CONSTANTS):
     yield
 
     cli_settings.CONFIG_PATH.unlink(missing_ok=True)
-    cli_settings.TOKENS_PATH.unlink(missing_ok=True)
+    cli_settings.TOKENS_FALLBACK_PATH.unlink(missing_ok=True)
 
 
 @pytest.fixture

--- a/tests/e2e_integration/playwright/test_personal_access_tokens.py
+++ b/tests/e2e_integration/playwright/test_personal_access_tokens.py
@@ -86,7 +86,7 @@ def test_new_pat_form_renders(logged_in_edit_user_pat_page: Page):
 def test_create_full_access_pat_shows_token(logged_in_edit_user_pat_page: Page):
     """
     Creating a PAT with no scope restrictions shows the 'Token generated' page,
-    the copy-now warning, and the raw token (which must start with 'divbase_pat_').
+    the copy-now warning, and the raw token (which must start with PAT_TOKEN_PREFIX set in divbase-lib's constants module).
     """
     fill_and_submit_new_pat_form(logged_in_edit_user_pat_page, name="my-hpc-token")
 

--- a/tests/unit/divbase_api/test_security.py
+++ b/tests/unit/divbase_api/test_security.py
@@ -17,6 +17,7 @@ from divbase_api.security import (
     verify_password,
     verify_token,
 )
+from divbase_lib.divbase_constants import PAT_TOKEN_PREFIX
 
 USER_ID = 1
 
@@ -121,7 +122,7 @@ def test_password_hashing():
 
 def test_personal_access_token_hashing():
     """Test that hashing a personal access token produces a consistent hash."""
-    raw_token = SecretStr("divbase_pat_abc123")
+    raw_token = SecretStr(f"{PAT_TOKEN_PREFIX}_abc123")
     hashed_token_1 = hash_personal_access_token(raw_token)
     hashed_token_2 = hash_personal_access_token(raw_token)
     assert hashed_token_1 == hashed_token_2

--- a/tests/unit/divbase_cli/test_config_resolver.py
+++ b/tests/unit/divbase_cli/test_config_resolver.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic import SecretStr
 
 from divbase_cli.cli_config import cli_settings
 from divbase_cli.cli_exceptions import AuthenticationError, ProjectNameNotSpecifiedError
@@ -12,6 +13,7 @@ from divbase_cli.config_resolver import (
     resolve_url_for_non_project_specific_commands,
 )
 from divbase_cli.user_config import ProjectConfig
+from divbase_lib.divbase_constants import PAT_TOKEN_PREFIX
 
 
 @pytest.fixture(autouse=True)
@@ -56,35 +58,26 @@ def test_ensure_logged_in_wrong_url():
         ensure_logged_in(desired_url="https://wrong-url.com")
 
 
-def test_ensure_logged_in_with_pat_and_desired_url():
+def test_ensure_logged_in_with_pat_and_desired_url(monkeypatch):
     """ensure_logged_in returns desired_url when no active session and DIVBASE_API_PAT is set."""
     mock_config = MagicMock()
     mock_config.logged_in_url = None
+    monkeypatch.setattr(cli_settings, "DIVBASE_API_PAT", SecretStr(f"{PAT_TOKEN_PREFIX}_abc123"))
 
-    with (
-        patch("divbase_cli.config_resolver.cli_settings") as mock_settings,
-        patch("divbase_cli.config_resolver.load_user_config", return_value=mock_config),
-    ):
-        mock_settings.DIVBASE_API_PAT = "divbase_pat_abc123"
-        mock_settings.DIVBASE_API_URL = "https://default.example.com"
-
+    with patch("divbase_cli.config_resolver.load_user_config", return_value=mock_config):
         result = ensure_logged_in(desired_url="https://project.example.com")
 
     assert result == "https://project.example.com"
 
 
-def test_ensure_logged_in_with_pat_and_no_desired_url():
+def test_ensure_logged_in_with_pat_and_no_desired_url(monkeypatch):
     """ensure_logged_in returns DIVBASE_API_URL when no active session and PAT is set but no desired_url given."""
     mock_config = MagicMock()
     mock_config.logged_in_url = None
+    monkeypatch.setattr(cli_settings, "DIVBASE_API_PAT", SecretStr(f"{PAT_TOKEN_PREFIX}_abc123"))
+    monkeypatch.setattr(cli_settings, "DIVBASE_API_URL", "https://default.example.com")
 
-    with (
-        patch("divbase_cli.config_resolver.cli_settings") as mock_settings,
-        patch("divbase_cli.config_resolver.load_user_config", return_value=mock_config),
-    ):
-        mock_settings.DIVBASE_API_PAT = "divbase_pat_abc123"
-        mock_settings.DIVBASE_API_URL = "https://default.example.com"
-
+    with patch("divbase_cli.config_resolver.load_user_config", return_value=mock_config):
         result = ensure_logged_in()
 
     assert result == "https://default.example.com"
@@ -133,18 +126,14 @@ def test_resolve_project_no_project_specified():
         )
 
 
-def test_resolve_url_for_non_project_specific_commands_with_pat():
+def test_resolve_url_for_non_project_specific_commands_with_pat(monkeypatch):
     """resolve_url_for_non_project_specific_commands returns DIVBASE_API_URL when no active session and PAT is set."""
     mock_config = MagicMock()
     mock_config.logged_in_url = None
+    monkeypatch.setattr(cli_settings, "DIVBASE_API_PAT", SecretStr(f"{PAT_TOKEN_PREFIX}_abc123"))
+    monkeypatch.setattr(cli_settings, "DIVBASE_API_URL", "https://default.example.com")
 
-    with (
-        patch("divbase_cli.config_resolver.cli_settings") as mock_settings,
-        patch("divbase_cli.config_resolver.load_user_config", return_value=mock_config),
-    ):
-        mock_settings.DIVBASE_API_PAT = "divbase_pat_abc123"
-        mock_settings.DIVBASE_API_URL = "https://default.example.com"
-
+    with patch("divbase_cli.config_resolver.load_user_config", return_value=mock_config):
         result = resolve_url_for_non_project_specific_commands()
 
     assert result == "https://default.example.com"

--- a/tests/unit/divbase_cli/test_user_auth.py
+++ b/tests/unit/divbase_cli/test_user_auth.py
@@ -10,11 +10,17 @@ from keyring.errors import KeyringError, NoKeyringError, PasswordDeleteError
 from pydantic import SecretStr
 
 from divbase_cli.cli_config import cli_settings
+from divbase_cli.cli_exceptions import AuthenticationError
 from divbase_cli.user_auth import (
+    PATData,
     TokenData,
     _delete_stored_jwts,
     check_existing_session,
+    delete_stored_pat,
+    get_pat_for_authentication,
+    load_stored_user_pat,
     load_user_tokens,
+    make_authenticated_request,
 )
 
 # cli config set to use "divbase-cli-test" (via pytest.ini) as the keyring service name,
@@ -27,7 +33,9 @@ def clean_up_keyring_entries():
     """Clean up any test keyring entries added after each test"""
     yield
     with contextlib.suppress(NoKeyringError, PasswordDeleteError):
-        keyring.delete_password(service_name=_TEST_KEYRING_SERVICE, username=cli_settings.KEYRING_USERNAME)
+        keyring.delete_password(service_name=_TEST_KEYRING_SERVICE, username=cli_settings.KEYRING_TOKENS_USERNAME)
+    with contextlib.suppress(NoKeyringError, PasswordDeleteError):
+        keyring.delete_password(service_name=_TEST_KEYRING_SERVICE, username=cli_settings.KEYRING_PATS_USERNAME)
 
 
 @pytest.fixture
@@ -105,7 +113,7 @@ def test_dump_tokens_falls_back_to_file_when_no_keyring(mock_set_password, mock_
     If attempt to dump tokens with keyring fails, tokens should be written to a file with 0600 permissions."""
     output = tmp_path / ".secrets"
 
-    mock_token_data.dump_tokens(output_path=output)
+    mock_token_data.dump_tokens(fallback_output_path=output)
 
     assert output.exists()
     file_mode = stat.S_IMODE(output.stat().st_mode)
@@ -117,7 +125,7 @@ def test_dump_tokens_falls_back_to_file_on_keyring_error(mock_set_password, mock
     """dump_tokens writes a 0600 file when an unexpected keyring error occurs."""
     output = tmp_path / ".secrets"
 
-    mock_token_data.dump_tokens(output_path=output)
+    mock_token_data.dump_tokens(fallback_output_path=output)
 
     assert output.exists()
     file_mode = stat.S_IMODE(output.stat().st_mode)
@@ -200,3 +208,151 @@ def test_load_user_tokens_keyring_takes_priority_over_file(mock_get_password, mo
     result = load_user_tokens(token_path=token_file)
     assert result is not None
     assert result.access_token.get_secret_value() == "keyring_access"
+
+
+@patch("divbase_cli.user_auth.httpx.request")
+@patch("divbase_cli.user_auth.load_user_tokens")
+def test_make_authenticated_request_uses_jwt_over_pat(mock_load_tokens, mock_request, mock_token_data, monkeypatch):
+    """JWT session should take priority over PAT when both are available."""
+    mock_load_tokens.return_value = mock_token_data
+    monkeypatch.setattr(cli_settings, "DIVBASE_API_PAT", SecretStr("divbase_pat_should_not_be_used"))
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_request.return_value = mock_response
+
+    make_authenticated_request(method="GET", divbase_base_url="https://example.com", api_route="v1/test")
+
+    auth_header = mock_request.call_args.kwargs["headers"]["Authorization"]
+    assert auth_header == f"Bearer {mock_token_data.access_token.get_secret_value()}"
+    assert "divbase_pat_should_not_be_used" not in auth_header
+
+
+@pytest.fixture
+def mock_pat_data():
+    return PATData(
+        name="test-pat",
+        pat=SecretStr("divbase_pat_faketoken"),
+        pat_expires_at=9999999999,
+    )
+
+
+@patch("divbase_cli.user_auth.keyring.set_password", side_effect=NoKeyringError)
+def test_dump_pat_data_falls_back_to_file_when_no_keyring(mock_set_password, mock_pat_data, tmp_path):
+    """dump_pat_data writes a 0600 file when keyring is unavailable."""
+    output = tmp_path / ".pat"
+
+    mock_pat_data.dump_pat_data(fallback_output_path=output)
+
+    assert output.exists()
+    file_mode = stat.S_IMODE(output.stat().st_mode)
+    # NOTE: this test has not been tried on windows, the test could fail there as windows doesn't use unix style permissions,
+    # we can consider dropping the 0600 part of the test if it becomes an issue.
+    # windows users will use keyring anyway so this is not a problem.
+    assert file_mode == 0o600
+
+
+@patch("divbase_cli.user_auth.keyring.get_password")
+def test_load_stored_user_pat_reads_from_keyring(mock_get_password, mock_pat_data, tmp_path):
+    """load_stored_user_pat returns PAT from keyring when present."""
+    mock_get_password.return_value = json.dumps(
+        {
+            "name": mock_pat_data.name,
+            "pat": mock_pat_data.pat.get_secret_value(),
+            "pat_expires_at": mock_pat_data.pat_expires_at,
+        }
+    )
+
+    result = load_stored_user_pat(pat_fallback_path=tmp_path / ".pat")
+
+    assert result is not None
+    assert result.name == "test-pat"
+    assert result.pat.get_secret_value() == "divbase_pat_faketoken"
+
+
+@patch("divbase_cli.user_auth.keyring.get_password", side_effect=NoKeyringError)
+def test_load_stored_user_pat_falls_back_to_file_when_no_keyring(mock_get_password, mock_pat_data, tmp_path):
+    """load_stored_user_pat reads from file when keyring is unavailable."""
+    pat_file = tmp_path / ".pat"
+    pat_file.write_text(
+        f"name: {mock_pat_data.name}\n"
+        f"pat: {mock_pat_data.pat.get_secret_value()}\n"
+        f"pat_expires_at: {mock_pat_data.pat_expires_at}\n"
+    )
+
+    result = load_stored_user_pat(pat_fallback_path=pat_file)
+
+    assert result is not None
+    assert result.name == "test-pat"
+
+
+@patch("divbase_cli.user_auth.keyring.get_password")
+def test_load_stored_user_pat_keyring_takes_priority_over_file(mock_get_password, mock_pat_data, tmp_path):
+    """When PAT exists in both keyring and fallback file, keyring takes priority."""
+    mock_get_password.return_value = json.dumps(
+        {
+            "name": "keyring-pat",
+            "pat": "divbase_pat_keyringtoken",
+            "pat_expires_at": mock_pat_data.pat_expires_at,
+        }
+    )
+    pat_file = tmp_path / ".pat"
+    pat_file.write_text(
+        f"name: {mock_pat_data.name}\n"
+        f"pat: {mock_pat_data.pat.get_secret_value()}\n"
+        f"pat_expires_at: {mock_pat_data.pat_expires_at}\n"
+    )
+
+    result = load_stored_user_pat(pat_fallback_path=pat_file)
+    assert result is not None
+    assert result.name == "keyring-pat"
+
+
+def test_get_pat_for_authentication_returns_env_var_pat(monkeypatch):
+    """get_pat_for_authentication returns env var PAT when set, without hitting keyring."""
+    env_pat = SecretStr("divbase_pat_from_env")
+    monkeypatch.setattr(cli_settings, "DIVBASE_API_PAT", env_pat)
+
+    result = get_pat_for_authentication()
+    assert result is env_pat
+
+
+@patch("divbase_cli.user_auth.load_stored_user_pat")
+def test_get_pat_for_authentication_raises_on_expired_pat(mock_load, mock_pat_data, monkeypatch):
+    """get_pat_for_authentication raises AuthenticationError when stored PAT is expired."""
+
+    monkeypatch.setattr(cli_settings, "DIVBASE_API_PAT", None)
+    mock_pat_data.pat_expires_at = int(time.time()) - 60
+    mock_load.return_value = mock_pat_data
+
+    with pytest.raises(AuthenticationError, match="expired"):
+        get_pat_for_authentication()
+
+
+@patch("divbase_cli.user_auth.keyring.delete_password", side_effect=PasswordDeleteError)
+def test_delete_stored_pat_can_run_multiple_times(mock_delete_password, tmp_path):
+    """delete_stored_pat should be idempotent."""
+    pat_file = tmp_path / ".pat"
+    delete_stored_pat(pat_file)
+    delete_stored_pat(pat_file)
+    delete_stored_pat(pat_file)
+
+
+@pytest.fixture
+def mock_pat_data_no_expiry():
+    return PATData(
+        name="no-expiry-pat",
+        pat=SecretStr("divbase_pat_noexpirytoken"),
+        pat_expires_at=None,
+    )
+
+
+@patch("divbase_cli.user_auth.load_stored_user_pat")
+def test_get_pat_for_authentication_no_expiry_pat_returns_pat(mock_load, mock_pat_data_no_expiry, monkeypatch):
+    """get_pat_for_authentication returns the PAT without raising when pat_expires_at is None."""
+    monkeypatch.setattr(cli_settings, "DIVBASE_API_PAT", None)
+    mock_load.return_value = mock_pat_data_no_expiry
+
+    result = get_pat_for_authentication()
+
+    assert result is not None
+    assert result.get_secret_value() == mock_pat_data_no_expiry.pat.get_secret_value()

--- a/tests/unit/divbase_cli/test_user_auth.py
+++ b/tests/unit/divbase_cli/test_user_auth.py
@@ -22,6 +22,7 @@ from divbase_cli.user_auth import (
     load_user_tokens,
     make_authenticated_request,
 )
+from divbase_lib.divbase_constants import PAT_TOKEN_PREFIX
 
 # cli config set to use "divbase-cli-test" (via pytest.ini) as the keyring service name,
 # so tokens and PATs stored in tests don't interfere with real credentials in dev computer with service name "divbase-cli"
@@ -214,8 +215,9 @@ def test_load_user_tokens_keyring_takes_priority_over_file(mock_get_password, mo
 @patch("divbase_cli.user_auth.load_user_tokens")
 def test_make_authenticated_request_uses_jwt_over_pat(mock_load_tokens, mock_request, mock_token_data, monkeypatch):
     """JWT session should take priority over PAT when both are available."""
+    raw_pat = f"{PAT_TOKEN_PREFIX}_should_not_be_used"
     mock_load_tokens.return_value = mock_token_data
-    monkeypatch.setattr(cli_settings, "DIVBASE_API_PAT", SecretStr("divbase_pat_should_not_be_used"))
+    monkeypatch.setattr(cli_settings, "DIVBASE_API_PAT", SecretStr(raw_pat))
     mock_response = MagicMock()
     mock_response.raise_for_status = MagicMock()
     mock_request.return_value = mock_response
@@ -224,14 +226,14 @@ def test_make_authenticated_request_uses_jwt_over_pat(mock_load_tokens, mock_req
 
     auth_header = mock_request.call_args.kwargs["headers"]["Authorization"]
     assert auth_header == f"Bearer {mock_token_data.access_token.get_secret_value()}"
-    assert "divbase_pat_should_not_be_used" not in auth_header
+    assert raw_pat not in auth_header
 
 
 @pytest.fixture
 def mock_pat_data():
     return PATData(
         name="test-pat",
-        pat=SecretStr("divbase_pat_faketoken"),
+        pat=SecretStr(f"{PAT_TOKEN_PREFIX}_faketoken"),
         pat_expires_at=9999999999,
     )
 
@@ -266,7 +268,7 @@ def test_load_stored_user_pat_reads_from_keyring(mock_get_password, mock_pat_dat
 
     assert result is not None
     assert result.name == "test-pat"
-    assert result.pat.get_secret_value() == "divbase_pat_faketoken"
+    assert result.pat.get_secret_value() == f"{PAT_TOKEN_PREFIX}_faketoken"
 
 
 @patch("divbase_cli.user_auth.keyring.get_password", side_effect=NoKeyringError)
@@ -291,7 +293,7 @@ def test_load_stored_user_pat_keyring_takes_priority_over_file(mock_get_password
     mock_get_password.return_value = json.dumps(
         {
             "name": "keyring-pat",
-            "pat": "divbase_pat_keyringtoken",
+            "pat": f"{PAT_TOKEN_PREFIX}_keyringtoken",
             "pat_expires_at": mock_pat_data.pat_expires_at,
         }
     )
@@ -309,7 +311,7 @@ def test_load_stored_user_pat_keyring_takes_priority_over_file(mock_get_password
 
 def test_get_pat_for_authentication_returns_env_var_pat(monkeypatch):
     """get_pat_for_authentication returns env var PAT when set, without hitting keyring."""
-    env_pat = SecretStr("divbase_pat_from_env")
+    env_pat = SecretStr(f"{PAT_TOKEN_PREFIX}_from_env")
     monkeypatch.setattr(cli_settings, "DIVBASE_API_PAT", env_pat)
 
     result = get_pat_for_authentication()
@@ -341,7 +343,7 @@ def test_delete_stored_pat_can_run_multiple_times(mock_delete_password, tmp_path
 def mock_pat_data_no_expiry():
     return PATData(
         name="no-expiry-pat",
-        pat=SecretStr("divbase_pat_noexpirytoken"),
+        pat=SecretStr(f"{PAT_TOKEN_PREFIX}_noexpirytoken"),
         pat_expires_at=None,
     )
 


### PR DESCRIPTION
This PR is a follow up of PR SQ-896: Store user JWTs in OS keyring_ #89. This covers the same idea but for personal access tokens (PATs) instead of the users access and refresh JWTs. I started working on this one a few weeks ago, but have re-implemnted on a new branch which is up to date with main. 

### Why:
Basic idea is that now a user can use `divbase-cli` to store/use their PATs for programmatic use. This avoids the need for them to use environment vars and potentially use bad practices when it comes to handling secrets (e.g. store the value in the bash history, define the value in a slurm script inside a project directory, which is by default readable to all members of the same project - by project here I mean a HPC project, not DivBase). It is still possible to instead use an env var if they want to, but it is not the recommend approach. 

### Summary of changes:
- 3 new cli subcommands added to divbase-cli auth:
	- `add-pat`   Add a personal access token (PAT) to your device for authentication with DivBase. 
	- `rm-pat `   Remove the stored personal access token from your device.
	- `pat-info`  Display information about the personal access token stored on this device, if any.  

- User Docs and the frontend PAT creation/management routes updated accordingly. see screenshot below for example view when user creates a PAT. 
- tests added to verify these new CLI commands and extra logic to handle which auth method to use. 
<img width="1032" height="1121" alt="Screenshot from 2026-06-03 13-54-56" src="https://github.com/user-attachments/assets/f78d6a94-86e8-48bf-b80f-5fa197db0ff8" />


### Priority Order for authentication with PATS vs logged in session (this is show in user facing docs):

    1. **Active login session** (from `divbase-cli auth login`) — highest priority
    2. **`DIVBASE_API_PAT` environment variable**
    3. **CLI-stored PAT** (from `divbase-cli auth add-pat`)

As logged in account will have the same or more permissions that a PATs, it is first. An env var allows a user to set a specific per job PAT, so makes sense I think to have as 2nd. The ordering needs to be defined, but essentially it is unlikely a user will ever have anymore than 1 of these things set. 

### To test it out basic functionality. 
- Login to divbase frontend, go to profile, manage tokens.
- Create a new token, scoping it as you like
- Copy paste the commands from the frontend page to add the PAT to the CLI tool.
- Run `divbase-cli auth pat-info` to see info about the PAT added.
- Run `divbase-cli auth rm-pat` to remove the PAT. 
- Make sure logged out and run a divbase-cli command and see the PAT in use. 
