### PR TITLE
SQ-831: Add new project role 'QUERY'

### DIFF
--- a/docs/development/personal_access_tokens.md
+++ b/docs/development/personal_access_tokens.md
@@ -24,7 +24,7 @@ class PATPermissions(BaseModel):
 | Scope | Meaning |
 |---|---|
 | `all_projects` | Access all projects the user is a member of, at their membership role |
-| `projects` | Access specific projects only; each project mapped to a max role (`read`, `edit`, `manage`) |
+| `projects` | Access specific projects only; each project mapped to a max role (`read`, `query`, `edit`, `manage`) |
 | `task_history` | Access the task history endpoints which are not project specific |
 
 Note that almost all divbase-api routes called by the CLI tool are project scoped. So they rely on the `get_project_member` dependency. The only exceptions to that are:

--- a/docs/user-guides/account-management.md
+++ b/docs/user-guides/account-management.md
@@ -11,20 +11,22 @@ Once your project is created, you will be added as a member with the **Manage** 
 
 ## Project roles and permissions
 
-Each project member is assigned one of three roles. The table below shows what each role can do with the `divbase-cli`.
+Each project member is assigned one of four roles. The table below shows what each role can do within the project using `divbase-cli`.
 
-| CLI Command | Read | Edit | Manage |
-|---|:---:|:---:|:---:|
-| `files ls` | ✓ | ✓ | ✓ |
-| `files download` / `files download-all` | ✓ | ✓ | ✓ |
-| `task-history user` | ✓ | ✓ | ✓ |
-| `files upload` | | ✓ | ✓ |
-| `query vcf` / `query tsv` | | ✓ | ✓ |
-| `dimensions update` | | ✓ | ✓ |
-| `version ls` | | ✓ | ✓ |
-| `version add` / `version rm` | | ✓ | ✓ |
-| `task-history project` | | | ✓ |
-| Add / remove project members <sup>1</sup>| | | ✓ |
+| CLI Command | Read | Query | Edit | Manage |
+|---|:---:|:---:|:---:|:---:|
+| `files ls` | ✓ | ✓ | ✓ | ✓ |
+| `files download` | ✓ | ✓ | ✓ | ✓ |
+| `version ls/info` | ✓ | ✓ | ✓ | ✓ |
+| `files upload` | | ✓ | ✓ | ✓ |
+| `query vcf` / `query tsv` | | ✓ | ✓ | ✓ |
+| `dimensions update` | | ✓ | ✓ | ✓ |
+| `task-history user` | | ✓ | ✓ | ✓ |
+| `version add` | | ✓ | ✓ | ✓ |
+| `files restore/rm` | | | ✓ | ✓ |
+| `version update/rm` | | | ✓ | ✓ |
+| `task-history project` | | | | ✓ |
+| Add / remove project members <sup>1</sup>| | | | ✓ |
 
 !!! note
     <sup>1</sup> Members management can be done by any project manager using the DivBase web interface, not `divbase-cli`.
@@ -36,7 +38,7 @@ Project members can be added by anyone with the **Manage** role on that project.
 1. Navigate to your project page via **Projects** in the navigation bar.
 2. Open the project you want to manage.
 3. In the **Members** section, click **Add Member**.
-4. Enter the email address of the person you want to add and select their role (`read`, `edit`, or `manage`).
+4. Enter the email address of the person you want to add and select their role (`read`, `query`, `edit`, or `manage`).
 5. Click **Add Member** to confirm.
 
 !!! note "The user must already have a DivBase account"

--- a/docs/user-guides/tutorial-query-on-public-data.md
+++ b/docs/user-guides/tutorial-query-on-public-data.md
@@ -1,6 +1,6 @@
 # Tutorial: Running a DivBase query on a public dataset
 
-This tutorial assumes that you have an account on DivBase and have a membership in a DivBase project with at least an EDIT role (i.e. can upload files and run queries). If this is your first time using DivBase, you may want to have a look at the [Quick Start guide](quick-start.md) before trying the tutorial out.
+This tutorial assumes that you have an account on DivBase and have a membership in a DivBase project with at least one 'QUERY' level role (i.e. can upload files and run queries). If this is your first time using DivBase, you may want to have a look at the [Quick Start guide](quick-start.md) before trying the tutorial out.
 
 We will use a mouse (_Mus musculus_) data set availalbe on the European Nucleotide Archive: <https://www.ebi.ac.uk/ena/browser/view/ERZ022025>. It a 5.5 Gb VCF.gz file that contains 18 samples and 66,007,044 variants.
 

--- a/docs/user-guides/tutorial-query-on-public-data.md
+++ b/docs/user-guides/tutorial-query-on-public-data.md
@@ -1,6 +1,6 @@
 # Tutorial: Running a DivBase query on a public dataset
 
-This tutorial assumes that you have an account on DivBase and have a membership in a DivBase project with at least one 'QUERY' level role (i.e. can upload files and run queries). If this is your first time using DivBase, you may want to have a look at the [Quick Start guide](quick-start.md) before trying the tutorial out.
+This tutorial assumes that you have an account on DivBase and are a member in a DivBase project with the role 'QUERY' (i.e. can upload files and run queries) or higher. If this is your first time using DivBase, you may want to have a look at the [Quick Start guide](quick-start.md) before trying the tutorial out.
 
 We will use a mouse (_Mus musculus_) data set availalbe on the European Nucleotide Archive: <https://www.ebi.ac.uk/ena/browser/view/ERZ022025>. It a 5.5 Gb VCF.gz file that contains 18 samples and 66,007,044 variants.
 

--- a/docs/user-guides/vcf-dimensions.md
+++ b/docs/user-guides/vcf-dimensions.md
@@ -22,7 +22,7 @@ divbase-cli task-history id 123
 ```
 
 !!! Warning
-    DivBase system does not automatically run `divbase-cli dimensions update` when files are uploaded. This needs to be manually done by one project member that has at least an EDIT role in the project.
+    DivBase system does not automatically run `divbase-cli dimensions update` when files are uploaded. This needs to be manually done by one project member that has the role 'QUERY' or higher in the project.
 
 There are four CLI commands sorted under `divbase-cli dimensions`:
 

--- a/packages/divbase-api/src/divbase_api/admin_panel.py
+++ b/packages/divbase-api/src/divbase_api/admin_panel.py
@@ -290,8 +290,6 @@ class ProjectView(ModelView):
             raise FormValidationError(errors={"is_active": "Cannot set a user to active that is also set as deleted."})
         return await super().validate(request=request, data=data)
 
-        return await super().validate(request=request, data=data)
-
     def handle_exception(self, exc: Exception) -> None:
         """
         sqlalchemy will raise an IntegrityError if an admin tries to create/edit a project to have either a

--- a/packages/divbase-api/src/divbase_api/crud/projects.py
+++ b/packages/divbase-api/src/divbase_api/crud/projects.py
@@ -15,7 +15,6 @@ from divbase_api.exceptions import (
     UserNotFoundError,
 )
 from divbase_api.models.projects import ProjectDB, ProjectMembershipDB, ProjectRoles
-from divbase_api.models.users import UserDB
 from divbase_api.schemas.projects import ProjectCreate, ProjectMemberResponse, UserProjectResponse
 
 
@@ -244,22 +243,3 @@ async def _validate_project_create(db: AsyncSession, name: str, bucket_name: str
     bucket_exists_result = await db.execute(bucket_exists_stmt)
     if bucket_exists_result.scalar():
         raise ProjectCreationError(f"Bucket name '{bucket_name}' is already in use")
-
-
-async def check_if_user_is_not_only_read_user_in_all_their_projects(db: AsyncSession, user_id: int) -> bool:
-    """
-    Check if a user has any project where they have at least an EDIT role.
-
-    Users with a READ role should not be able to view tasks from a project (since they cannot submit task there in the first place).
-    But if there is no project where they have a role with higher permissions than READ, they should not be able to see the task history
-    at all. Instead of just returning an empty task history table, they should get a special error message informing them of this.
-    """
-
-    stmt = select(ProjectMembershipDB.role).join_from(UserDB, ProjectMembershipDB).where(UserDB.id == user_id)
-
-    result = await db.execute(stmt)
-    rows = result.fetchall()
-
-    users_roles_unique = set(row[0] for row in rows)
-
-    return any(role in ("manage", "edit") for role in users_roles_unique)

--- a/packages/divbase-api/src/divbase_api/crud/projects.py
+++ b/packages/divbase-api/src/divbase_api/crud/projects.py
@@ -207,8 +207,9 @@ async def remove_project_member(db: AsyncSession, project_id: int, user_id: int)
 
 ROLE_HIERARCHY = {
     ProjectRoles.READ: 1,
-    ProjectRoles.EDIT: 2,
-    ProjectRoles.MANAGE: 3,
+    ProjectRoles.QUERY: 2,
+    ProjectRoles.EDIT: 3,
+    ProjectRoles.MANAGE: 4,
 }
 
 

--- a/packages/divbase-api/src/divbase_api/migrations/versions/2026-06-09_add_query_as_project_role.py
+++ b/packages/divbase-api/src/divbase_api/migrations/versions/2026-06-09_add_query_as_project_role.py
@@ -1,0 +1,40 @@
+"""add_query_as_project_role
+
+Revision ID: 9885301b9073
+Revises: 427a022ebccf
+Create Date: 2026-06-09 14:10:27.943160
+
+This migration adds the new project role QUERY.
+
+Enums in Postgres are a little special, hence the below steps.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "9885301b9073"
+down_revision: Union[str, Sequence[str], None] = "427a022ebccf"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # manually created steps to add the QUERY role to the projectroles enum
+    # Convert the colum to string first, so we can drop and then recreate the new enum type safely.
+    op.execute("ALTER TABLE project_membership ALTER COLUMN role TYPE VARCHAR(50)")
+    op.execute("DROP TYPE projectroles")
+    op.execute("CREATE TYPE projectroles AS ENUM ('READ', 'QUERY', 'EDIT', 'MANAGE')")
+    op.execute("ALTER TABLE project_membership ALTER COLUMN role TYPE projectroles USING role::projectroles")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Like upgrade reversed, but we just reset any QUERY roles to READ first
+    op.execute("UPDATE project_membership SET role = 'READ' WHERE role = 'QUERY'")
+    op.execute("ALTER TABLE project_membership ALTER COLUMN role TYPE VARCHAR(50)")
+    op.execute("DROP TYPE projectroles")
+    op.execute("CREATE TYPE projectroles AS ENUM ('READ', 'EDIT', 'MANAGE')")
+    op.execute("ALTER TABLE project_membership ALTER COLUMN role TYPE projectroles USING role::projectroles")

--- a/packages/divbase-api/src/divbase_api/migrations/versions/2026-06-09_add_query_as_project_role.py
+++ b/packages/divbase-api/src/divbase_api/migrations/versions/2026-06-09_add_query_as_project_role.py
@@ -23,7 +23,7 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     """Upgrade schema."""
     # manually created steps to add the QUERY role to the projectroles enum
-    # Convert the colum to string first, so we can drop and then recreate the new enum type safely.
+    # Convert the column to string first, so we can drop and then recreate the new enum type safely.
     op.execute("ALTER TABLE project_membership ALTER COLUMN role TYPE VARCHAR(50)")
     op.execute("DROP TYPE projectroles")
     op.execute("CREATE TYPE projectroles AS ENUM ('READ', 'QUERY', 'EDIT', 'MANAGE')")

--- a/packages/divbase-api/src/divbase_api/models/projects.py
+++ b/packages/divbase-api/src/divbase_api/models/projects.py
@@ -53,8 +53,8 @@ class ProjectRoles(StrEnum):
     Roles assignable to a user in a project (higher role includes permissions of the lower roles):
 
     - READ: Can view project and download files
-    - QUERY: Can submit queries
-    - EDIT: Can add/edit/(soft)delete files + submit queries.
+    - QUERY: Can READ + upload files and submit queries
+    - EDIT: Can QUERY + (soft)delete files and project versions.
     - MANAGE: Can EDIT + add/remove users and change their roles.
 
     Note: Admin users do not need to be assigned to projects.

--- a/packages/divbase-api/src/divbase_api/models/projects.py
+++ b/packages/divbase-api/src/divbase_api/models/projects.py
@@ -50,17 +50,19 @@ class ProjectDB(BaseDBModel):
 
 class ProjectRoles(StrEnum):
     """
-    Roles assignable to a user in a project.
+    Roles assignable to a user in a project (higher role includes permissions of the lower roles):
 
     - READ: Can view project and download files
+    - QUERY: Can submit queries
     - EDIT: Can add/edit/(soft)delete files + submit queries.
     - MANAGE: Can EDIT + add/remove users and change their roles.
 
-    Note: Admin users do not need to be assigned to projects,
-    but have access to all projects.
+    Note: Admin users do not need to be assigned to projects.
+    The admin panel can be used by admins to manage any project.
     """
 
     READ = "read"
+    QUERY = "query"
     EDIT = "edit"
     MANAGE = "manage"
 

--- a/packages/divbase-api/src/divbase_api/routes/project_versions.py
+++ b/packages/divbase-api/src/divbase_api/routes/project_versions.py
@@ -56,8 +56,10 @@ async def add_version_endpoint(
     The entry specifies the current state of all files in the project.
     """
     project, current_user, role = project_and_user_and_role
-    if not has_required_role(role, ProjectRoles.EDIT):
-        raise AuthorizationError("You don't have permission to add a new project version to this project.")
+    if not has_required_role(role, ProjectRoles.QUERY):
+        raise AuthorizationError(
+            "You don't have permission to add a new project version to this project, you need at least 'QUERY' level permissions."
+        )
 
     new_version = await add_project_version(
         db=db,

--- a/packages/divbase-api/src/divbase_api/routes/queries.py
+++ b/packages/divbase-api/src/divbase_api/routes/queries.py
@@ -42,7 +42,9 @@ logger = structlog.get_logger(__name__)
 
 query_router = APIRouter()
 
-# TODO harmonize function names
+QUERY_AUTHORIZATION_ERROR_MSG = (
+    "You don't have permission to query this project. You need at least 'QUERY' level permissions."
+)
 
 
 @query_router.post(
@@ -61,8 +63,8 @@ async def submit_sample_metadata_query_job_endpoint(
     """
     project, current_user, role = project_and_user_and_role
 
-    if not has_required_role(role, ProjectRoles.EDIT):
-        raise AuthorizationError("You don't have permission to query this project.")
+    if not has_required_role(role, ProjectRoles.QUERY):
+        raise AuthorizationError(QUERY_AUTHORIZATION_ERROR_MSG)
     await check_queue_closed_for_new_tasks(db=db, is_admin=current_user.is_admin)
 
     task_kwargs = SampleMetadataQueryKwargs(
@@ -125,8 +127,8 @@ async def submit_vcf_query_job_endpoint(
     """
     project, current_user, role = project_and_user_and_role
 
-    if not has_required_role(role, ProjectRoles.EDIT):
-        raise AuthorizationError("You don't have permission to query this project.")
+    if not has_required_role(role, ProjectRoles.QUERY):
+        raise AuthorizationError(QUERY_AUTHORIZATION_ERROR_MSG)
     await check_queue_closed_for_new_tasks(db=db, is_admin=current_user.is_admin)
 
     if bcftools_query_request.samples is not None:

--- a/packages/divbase-api/src/divbase_api/routes/s3.py
+++ b/packages/divbase-api/src/divbase_api/routes/s3.py
@@ -48,7 +48,9 @@ logger = structlog.get_logger(__name__)
 
 s3_router = APIRouter()
 
-UPLOAD_AUTHORIZATION_ERROR_MSG = "You don't have permission to upload files to this project."
+UPLOAD_AUTHORIZATION_ERROR_MSG = (
+    "You don't have permission to upload files to this project. You need at least 'QUERY' level permissions."
+)
 
 
 def check_too_many_objects_in_request(
@@ -145,7 +147,7 @@ async def get_object_info(
     """Get details about all versions of a specific object/file in the project's store."""
     project, current_user, role = project_and_user_and_role
     if not has_required_role(role, ProjectRoles.READ):
-        raise AuthorizationError("You don't have permission to list files in this project.")
+        raise AuthorizationError("You don't have permission to get info about files in this project.")
 
     return await run_in_threadpool(
         s3_file_manager.get_detailed_object_info,
@@ -172,7 +174,7 @@ async def generate_single_part_upload_urls(
     Larger files must use multipart upload.
     """
     project, current_user, role = project_and_user_and_role
-    if not has_required_role(role, ProjectRoles.EDIT):
+    if not has_required_role(role, ProjectRoles.QUERY):
         raise AuthorizationError(UPLOAD_AUTHORIZATION_ERROR_MSG)
 
     check_too_many_objects_in_request(numb_objects=len(objects))
@@ -200,7 +202,7 @@ async def create_multi_part_upload(
     project_and_user_and_role: tuple[ProjectDB, UserDB, ProjectRoles] = Depends(get_project_member),
 ):
     project, current_user, role = project_and_user_and_role
-    if not has_required_role(role, ProjectRoles.EDIT):
+    if not has_required_role(role, ProjectRoles.QUERY):
         raise AuthorizationError(UPLOAD_AUTHORIZATION_ERROR_MSG)
 
     return await run_in_threadpool(
@@ -222,7 +224,7 @@ async def get_pre_signed_urls_parts(
     project_and_user_and_role: tuple[ProjectDB, UserDB, ProjectRoles] = Depends(get_project_member),
 ):
     project, current_user, role = project_and_user_and_role
-    if not has_required_role(role, ProjectRoles.EDIT):
+    if not has_required_role(role, ProjectRoles.QUERY):
         raise AuthorizationError(UPLOAD_AUTHORIZATION_ERROR_MSG)
 
     numb_parts = parts_request.parts_range_end - parts_request.parts_range_start + 1
@@ -254,7 +256,7 @@ async def complete_multipart_upload(
     project_and_user_and_role: tuple[ProjectDB, UserDB, ProjectRoles] = Depends(get_project_member),
 ):
     project, current_user, role = project_and_user_and_role
-    if not has_required_role(role, ProjectRoles.EDIT):
+    if not has_required_role(role, ProjectRoles.QUERY):
         raise AuthorizationError(UPLOAD_AUTHORIZATION_ERROR_MSG)
 
     return await run_in_threadpool(
@@ -276,7 +278,7 @@ async def abort_multipart_upload(
     project_and_user_and_role: tuple[ProjectDB, UserDB, ProjectRoles] = Depends(get_project_member),
 ):
     project, current_user, role = project_and_user_and_role
-    if not has_required_role(role, ProjectRoles.EDIT):
+    if not has_required_role(role, ProjectRoles.QUERY):
         raise AuthorizationError(UPLOAD_AUTHORIZATION_ERROR_MSG)
 
     s3_signer_service.abort_multipart_upload(
@@ -301,7 +303,9 @@ async def soft_delete_files(
     """
     project, current_user, role = project_and_user_and_role
     if not has_required_role(role, ProjectRoles.EDIT):
-        raise AuthorizationError("You don't have permission to soft delete files in this project.")
+        raise AuthorizationError(
+            f"You don't have permission to soft delete files for this project. You need at least '{ProjectRoles.EDIT}' level permissions."
+        )
 
     check_too_many_objects_in_request(numb_objects=len(objects))
 
@@ -329,7 +333,9 @@ async def restore_soft_deleted_files(
     """
     project, current_user, role = project_and_user_and_role
     if not has_required_role(role, ProjectRoles.EDIT):
-        raise AuthorizationError("You don't have permission to restore files in this project.")
+        raise AuthorizationError(
+            f"You don't have permission to restore files for this project. You need at least '{ProjectRoles.EDIT}' level permissions."
+        )
 
     check_too_many_objects_in_request(numb_objects=len(objects))
 

--- a/packages/divbase-api/src/divbase_api/routes/task_history.py
+++ b/packages/divbase-api/src/divbase_api/routes/task_history.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing_extensions import Annotated
 
-from divbase_api.crud.projects import check_if_user_is_not_only_read_user_in_all_their_projects, has_required_role
+from divbase_api.crud.projects import has_required_role
 from divbase_api.crud.task_history import get_tasks_pg
 from divbase_api.db import get_db
 from divbase_api.deps import get_project_member, require_task_history_scope
@@ -23,8 +23,6 @@ logger = structlog.get_logger(__name__)
 
 task_history_router = APIRouter()
 
-READ_USER_ERROR_MSG = "You do not have access view to task history from any projects. You need to have at least one project where you have an EDIT role or higher."
-
 
 @task_history_router.get("/tasks/user", status_code=status.HTTP_200_OK, response_model=list[TaskHistoryResult])
 async def get_all_tasks_for_user(
@@ -32,7 +30,8 @@ async def get_all_tasks_for_user(
     db: AsyncSession = Depends(get_db),
 ) -> list[TaskHistoryResult]:
     """
-    Get the task history for the current user. Admin users can view all tasks (even if not member of the projects), non-admin users can only view their own tasks.
+    Get the task history for the current user.
+    Admin users can view all tasks (even if not member of the projects), non-admin users can only view their own tasks.
     """
 
     serialized_tasks = await get_tasks_pg(
@@ -40,19 +39,7 @@ async def get_all_tasks_for_user(
         user_id=current_user.id,
         is_admin=current_user.is_admin,
     )
-    result = deserialize_tasks_to_result(serialized_tasks)
-
-    if not result:
-        user_has_at_least_one_edit_role = await check_if_user_is_not_only_read_user_in_all_their_projects(
-            db=db,
-            user_id=current_user.id,
-        )
-
-        if not user_has_at_least_one_edit_role:
-            raise AuthorizationError(READ_USER_ERROR_MSG)
-
-    # result.user_email = current_user.email
-    return result
+    return deserialize_tasks_to_result(serialized_tasks)
 
 
 @task_history_router.get(
@@ -71,7 +58,7 @@ async def get_all_tasks_for_user_and_project(
 
     if not has_required_role(role, ProjectRoles.EDIT):
         raise AuthorizationError(
-            "Project not found or you don't have permission to view task history from this project."
+            "Project not found or you don't have permission to view task history for this project."
         )
 
     serialized_tasks = await get_tasks_pg(
@@ -80,9 +67,7 @@ async def get_all_tasks_for_user_and_project(
         project_id=project.id,
         is_admin=current_user.is_admin,
     )
-    result = deserialize_tasks_to_result(serialized_tasks)
-    # result.user_email = current_user.email
-    return result
+    return deserialize_tasks_to_result(serialized_tasks)
 
 
 @task_history_router.get(
@@ -135,5 +120,4 @@ async def get_task_by_id(
     if not serialized_task:
         raise AuthorizationError("Task ID not found or you don't have permission to view the history for this task ID.")
 
-    result = deserialize_tasks_to_result(serialized_task)
-    return result
+    return deserialize_tasks_to_result(serialized_task)

--- a/packages/divbase-api/src/divbase_api/routes/task_history.py
+++ b/packages/divbase-api/src/divbase_api/routes/task_history.py
@@ -33,7 +33,6 @@ async def get_all_tasks_for_user(
     Get the task history for the current user.
     Admin users can view all tasks (even if not member of the projects), non-admin users can only view their own tasks.
     """
-
     serialized_tasks = await get_tasks_pg(
         db=db,
         user_id=current_user.id,
@@ -51,14 +50,13 @@ async def get_all_tasks_for_user_and_project(
     db: AsyncSession = Depends(get_db),
 ) -> list[TaskHistoryResult]:
     """
-    Get the task history for the current user and project. Admin users can view all tasks of the project (even if not member of the projects), non-admin users can only view their own tasks of the project.
+    Get the task history for the current user and project.
+    Admin users can view all tasks of the project (even if not member of the projects), non-admin users can only view their own tasks of the project.
     """
-
     project, current_user, role = project_and_user_and_role
-
-    if not has_required_role(role, ProjectRoles.EDIT):
+    if not has_required_role(role, ProjectRoles.QUERY) and not current_user.is_admin:
         raise AuthorizationError(
-            "Project not found or you don't have permission to view task history for this project."
+            "You don't have permission to view task history for this project. You need at least 'QUERY' level permissions for this."
         )
 
     serialized_tasks = await get_tasks_pg(
@@ -79,14 +77,13 @@ async def get_project_tasks(
     db: AsyncSession = Depends(get_db),
 ) -> list[TaskHistoryResult]:
     """
-    Get the task history for a project. Requires MANAGE role or higher. Admin users can view all tasks of the project (even if not member of the projects).
+    Get the task history for a project. Requires MANAGE role or higher.
+    Admin users can view all tasks of the project (even if not member of the projects).
     """
-
     project, current_user, role = project_and_user_and_role
-
     if not has_required_role(role, ProjectRoles.MANAGE) and not current_user.is_admin:
         raise AuthorizationError(
-            "Project not found or you don't have permission to view task history for this whole project."
+            "You don't have permission to view all task history for this project. You need 'MANAGE' level permissions for this."
         )
 
     serialized_tasks = await get_tasks_pg(db=db, project_id=project.id)
@@ -108,7 +105,6 @@ async def get_task_by_id(
 
     Since the request body does not include project ID, permissions checks are made in get_tasks_pg.
     """
-
     serialized_task = await get_tasks_pg(
         db=db,
         user_task_id=user_task_id,

--- a/packages/divbase-api/src/divbase_api/routes/vcf_dimensions.py
+++ b/packages/divbase-api/src/divbase_api/routes/vcf_dimensions.py
@@ -91,8 +91,10 @@ async def update_vcf_dimensions_endpoint(
     """
     project, current_user, role = project_and_user_and_role
 
-    if not has_required_role(role, ProjectRoles.EDIT):
-        raise AuthorizationError("You don't have permission to update VCF dimensions for this project.")
+    if not has_required_role(role, ProjectRoles.QUERY):
+        raise AuthorizationError(
+            "You don't have permission to update VCF dimensions, you need at least 'QUERY' level permissions."
+        )
     await check_queue_closed_for_new_tasks(db=db, is_admin=current_user.is_admin)
 
     task_kwargs = DimensionUpdateKwargs(

--- a/packages/divbase-api/src/divbase_api/static/css/styles.css
+++ b/packages/divbase-api/src/divbase_api/static/css/styles.css
@@ -411,8 +411,18 @@ body {
   background-color: var(--scilife-grape);
   color: white;
 }
+/* other scilife colors give too low contrast */
+.scilife-role-badge-query {
+  background-color: darkblue;
+  color: white;
+}
 .scilife-role-badge-read {
   background-color: var(--scilife-dark-grey);
+  color: white;
+}
+
+.scilife-role-badge-active {
+  background-color: var(--scilife-grape);
   color: white;
 }
 .scilife-role-badge-inactive {

--- a/packages/divbase-api/src/divbase_api/templates/components/add_user_to_project.html
+++ b/packages/divbase-api/src/divbase_api/templates/components/add_user_to_project.html
@@ -29,17 +29,22 @@
                     <div class="mb-3">
                         <label for="project_role" class="form-label">
                             Project Role <span class="text-danger">*</span>
+                            <br>
+                            <small class="text-muted">Higher roles inherit all permissions from lower roles</small>
                         </label>
                         <select class="form-select" id="project_role" name="role" required>
                             <option value="">Select a role...</option>
                             <option value="read">
-                                <i class="bi bi-eye"></i> Read - Can view and download files
+                                <i class="bi bi-eye"></i> 1. Read - Can view and download files
+                            </option>
+                            <option value="query">
+                                <i class="bi bi-search"></i> 2. Query - Can run queries and upload files. 
                             </option>
                             <option value="edit">
-                                <i class="bi bi-pencil"></i> Edit - Can upload, modify, and delete files
+                                <i class="bi bi-pencil"></i> 3. Edit - Can modify and delete files
                             </option>
                             <option value="manage">
-                                <i class="bi bi-shield"></i> Manage - Full project management access
+                                <i class="bi bi-shield"></i> 4. Manage - manage project access and view all queries submitted to the project
                             </option>
                         </select>
                         <div class="form-text">

--- a/packages/divbase-api/src/divbase_api/templates/components/add_user_to_project.html
+++ b/packages/divbase-api/src/divbase_api/templates/components/add_user_to_project.html
@@ -34,18 +34,10 @@
                         </label>
                         <select class="form-select" id="project_role" name="role" required>
                             <option value="">Select a role...</option>
-                            <option value="read">
-                                <i class="bi bi-eye"></i> 1. Read - Can view and download files
-                            </option>
-                            <option value="query">
-                                <i class="bi bi-search"></i> 2. Query - Can run queries and upload files. 
-                            </option>
-                            <option value="edit">
-                                <i class="bi bi-pencil"></i> 3. Edit - Can modify and delete files
-                            </option>
-                            <option value="manage">
-                                <i class="bi bi-shield"></i> 4. Manage - manage project access and view all queries submitted to the project
-                            </option>
+                            <option value="read">1. Read - Can view and download files</option>
+                            <option value="query">2. Query - Can run queries and upload files. </option>
+                            <option value="edit">3. Edit - Can modify and delete files</option>
+                            <option value="manage">4. Manage - manage project access and view all queries submitted to the project</option>
                         </select>
                         <div class="form-text">
                             <a href="{{ mkdocs_site_url }}/user-guides/account-management/#project-roles-and-permissions"

--- a/packages/divbase-api/src/divbase_api/templates/components/project_members.html
+++ b/packages/divbase-api/src/divbase_api/templates/components/project_members.html
@@ -58,7 +58,7 @@
                                 <td class="text-center">
                                     {% if member.user_id == current_user.id %}
                                     <!-- can't modify your own role -->
-                                    <span class="text-muted small"></i>N/A</span>
+                                    <span class="text-muted small">N/A</span>
                                     {% else %}
                                     <!-- Edit dropdown for other members -->
                                     <div class="dropdown">

--- a/packages/divbase-api/src/divbase_api/templates/components/project_members.html
+++ b/packages/divbase-api/src/divbase_api/templates/components/project_members.html
@@ -57,10 +57,8 @@
                                 {% if project.user_role == 'manage' %}
                                 <td class="text-center">
                                     {% if member.user_id == current_user.id %}
-                                    <!-- Manager can't edit their own role -->
-                                    <span class="text-muted small">
-                                        <i class="bi bi-shield-check me-1"></i>Owner
-                                    </span>
+                                    <!-- can't modify your own role -->
+                                    <span class="text-muted small"></i>N/A</span>
                                     {% else %}
                                     <!-- Edit dropdown for other members -->
                                     <div class="dropdown">
@@ -80,6 +78,16 @@
                                                             {% if member.role == 'read' %}disabled{% endif %}>
                                                         <i class="bi bi-eye me-2"></i>Read
                                                         {% if member.role == 'read' %}<i class="bi bi-check-lg ms-auto text-success"></i>{% endif %}
+                                                    </button>
+                                                </form>
+                                            </li>
+                                            <li>
+                                                <form method="post" action="/projects/{{ project.id }}/members/{{ member.user_id }}/role" style="display: inline;">
+                                                    <input type="hidden" name="role" value="query">
+                                                    <button class="dropdown-item" type="submit" 
+                                                            {% if member.role == 'query' %}disabled{% endif %}>
+                                                        <i class="bi bi-search me-2"></i>Query
+                                                        {% if member.role == 'query' %}<i class="bi bi-check-lg ms-auto text-success"></i>{% endif %}
                                                     </button>
                                                 </form>
                                             </li>

--- a/packages/divbase-api/src/divbase_api/templates/pats_pages/new_personal_access_token.html
+++ b/packages/divbase-api/src/divbase_api/templates/pats_pages/new_personal_access_token.html
@@ -155,6 +155,10 @@
                                                         {{ 'selected' if form_projects and form_projects.get(project.id | string) == 'read' }}>
                                                         Read
                                                     </option>
+                                                    <option value="query"
+                                                        {{ 'selected' if form_projects and form_projects.get(project.id | string) == 'query' }}>
+                                                        Query
+                                                    </option>
                                                     <option value="edit"
                                                         {{ 'selected' if form_projects and form_projects.get(project.id | string) == 'edit' }}>
                                                         Edit

--- a/packages/divbase-api/src/divbase_api/templates/project_pages/detail.html
+++ b/packages/divbase-api/src/divbase_api/templates/project_pages/detail.html
@@ -71,6 +71,11 @@
                             {% set to_copy = "divbase-cli config add " ~ project.name %}
                             {% include "components/copy_to_clipboard.html" %}
                         </div>
+                        <div class="card-body">
+                            <p class="text-muted">To make it your default project you can instead run:</p>
+                            {% set to_copy = "divbase-cli config add " ~ project.name ~ " --default" %}
+                            {% include "components/copy_to_clipboard.html" %}
+                        </div>
                     </div>
                 </div>
             </div>
@@ -82,6 +87,31 @@
             {% include "components/add_user_to_project.html" %}
         {% endif %}
             
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="card shadow-sm">
+                    <div class="card-header d-flex justify-content-between align-items-start">
+                        <div>
+                            <h5 class="mb-1"><i class="bi bi-shield-check me-2"></i>Project Role Permissions</h5>
+                            <small class="text-muted">Higher roles inherit all permissions from lower roles</small>
+                        </div>
+                        <a href="{{ mkdocs_site_url }}/user-guides/account-management/#project-roles-and-permissions"
+                           class="small text-muted flex-shrink-0 ms-3" target="_blank" rel="noopener">
+                            <i class="bi bi-box-arrow-up-right me-1"></i>Full breakdown of each role
+                        </a>
+                    </div>
+                    <div class="card-body">
+                        <ul class="list-unstyled d-flex flex-wrap gap-3 mb-0">
+                            <li><span class="badge scilife-role-badge-read me-1">Read</span><small class="text-muted">View and download files</small></li>
+                            <li><span class="badge scilife-role-badge-query me-1">Query</span><small class="text-muted">Upload files, submit queries, and add versions</small></li>
+                            <li><span class="badge scilife-role-badge-edit me-1">Edit</span><small class="text-muted">delete files and remove versions</small></li>
+                            <li><span class="badge scilife-role-badge-manage me-1">Manage</span><small class="text-muted">add and remove project members</small></li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+
     </div>
 </div>
 {% endblock %}

--- a/packages/divbase-api/src/divbase_api/templates/project_pages/detail.html
+++ b/packages/divbase-api/src/divbase_api/templates/project_pages/detail.html
@@ -104,8 +104,8 @@
                         <ul class="list-unstyled d-flex flex-wrap gap-3 mb-0">
                             <li><span class="badge scilife-role-badge-read me-1">Read</span><small class="text-muted">View and download files</small></li>
                             <li><span class="badge scilife-role-badge-query me-1">Query</span><small class="text-muted">Upload files, submit queries, and add versions</small></li>
-                            <li><span class="badge scilife-role-badge-edit me-1">Edit</span><small class="text-muted">delete files and remove versions</small></li>
-                            <li><span class="badge scilife-role-badge-manage me-1">Manage</span><small class="text-muted">add and remove project members</small></li>
+                            <li><span class="badge scilife-role-badge-edit me-1">Edit</span><small class="text-muted">Delete files and remove versions</small></li>
+                            <li><span class="badge scilife-role-badge-manage me-1">Manage</span><small class="text-muted">Add and remove project members</small></li>
                         </ul>
                     </div>
                 </div>

--- a/packages/divbase-lib/src/divbase_lib/api_schemas/personal_access_tokens.py
+++ b/packages/divbase-lib/src/divbase_lib/api_schemas/personal_access_tokens.py
@@ -7,7 +7,7 @@ from typing_extensions import Self
 
 # This needs to stay in sync with ProjectRoles in divbase-api.
 # Redefined here to avoid a circular dependency on divbase-api.
-ALLOWED_PROJECT_ROLES = ["read", "edit", "manage"]
+ALLOWED_PROJECT_ROLES = ["read", "query", "edit", "manage"]
 
 
 class PATPermissions(BaseModel):

--- a/tests/e2e_integration/cli_commands/conftest.py
+++ b/tests/e2e_integration/cli_commands/conftest.py
@@ -12,10 +12,12 @@ import logging
 
 import keyring
 import pytest
+from click.testing import Result
 from keyring.errors import KeyringError
 from typer.testing import CliRunner
 
 from divbase_cli.cli_config import cli_settings
+from divbase_cli.cli_exceptions import DivBaseAPIError
 from divbase_cli.divbase_cli import app
 
 runner = CliRunner()
@@ -74,6 +76,12 @@ def logged_in_admin_with_existing_config(CONSTANTS):
 def logged_in_read_user_with_existing_config(CONSTANTS):
     """Fixture to provide a logged in read user with existing config."""
     yield from _create_logged_in_user_fixture("read user")(CONSTANTS)
+
+
+@pytest.fixture
+def logged_in_query_user_with_existing_config(CONSTANTS):
+    """Fixture to provide a logged in query user with existing config."""
+    yield from _create_logged_in_user_fixture("query user")(CONSTANTS)
 
 
 @pytest.fixture
@@ -157,3 +165,10 @@ def _create_logged_in_user_fixture(user_type: str):
         cli_settings.PATS_FALLBACK_PATH.unlink(missing_ok=True)
 
     return factory
+
+
+def assert_divbase_403_permissions_error(result: Result) -> None:
+    """Helper function to assert a cli cmd result is a DivBaseAPIError with a 403 permissions error."""
+    assert result.exit_code != 0
+    assert isinstance(result.exception, DivBaseAPIError)
+    assert "403" in str(result.exception)

--- a/tests/e2e_integration/cli_commands/test_dimensions_cli.py
+++ b/tests/e2e_integration/cli_commands/test_dimensions_cli.py
@@ -94,6 +94,15 @@ def test_update_vcf_dimensions_task_directly(
         assert vcf_file in indexed_files, f"{vcf_file} not found in indexed files: {indexed_files}"
 
 
+def test_read_user_cannot_trigger_dimensions_update(logged_in_read_user_with_existing_config, CONSTANTS):
+    """Read role cannot trigger a dimensions update."""
+    project = CONSTANTS["CLEANED_PROJECT"]
+    result = runner.invoke(app, f"dimensions update --project {project}")
+    assert result.exit_code != 0
+    assert isinstance(result.exception, DivBaseAPIError)
+    assert "403" in str(result.exception)
+
+
 def test_show_vcf_dimensions_task(
     CONSTANTS,
     run_update_dimensions,

--- a/tests/e2e_integration/cli_commands/test_file_cli.py
+++ b/tests/e2e_integration/cli_commands/test_file_cli.py
@@ -23,6 +23,7 @@ from divbase_lib.divbase_constants import (
     S3_MULTIPART_UPLOAD_THRESHOLD,
 )
 from divbase_lib.s3_checksums import calculate_composite_md5_s3_etag
+from tests.e2e_integration.cli_commands.conftest import assert_divbase_403_permissions_error
 
 runner = CliRunner()
 
@@ -294,7 +295,7 @@ def test_file_info_after_reupload(logged_in_edit_user_with_existing_config, CONS
     assert calculate_numb_table_rows_printed(result.stdout) == 2
 
 
-def test_upload_1_file(logged_in_edit_user_with_existing_config, tmp_path):
+def test_upload_1_file(logged_in_query_user_with_existing_config, tmp_path):
     """Test upload 1 file to the project."""
     test_file = tmp_path / "fake_test_file.tsv"
     test_file.write_text("testing, testing 1 2 3...")
@@ -306,7 +307,7 @@ def test_upload_1_file(logged_in_edit_user_with_existing_config, tmp_path):
     assert test_file.name in result.stdout
 
 
-def test_upload_1_file_to_non_default_project(logged_in_edit_user_with_existing_config, CONSTANTS, fixtures_dir):
+def test_upload_1_file_to_non_default_project(logged_in_query_user_with_existing_config, CONSTANTS, fixtures_dir):
     """Specify a project when uploading a file."""
     test_file = (fixtures_dir / CONSTANTS["FILES_TO_UPLOAD_DOWNLOAD"][0]).resolve()
 
@@ -328,7 +329,7 @@ def test_upload_multiple_files_at_once(logged_in_edit_user_with_existing_config,
         assert f"{str(file)}" in result.stdout
 
 
-def test_upload_dir_contents(logged_in_edit_user_with_existing_config, CONSTANTS, fixtures_dir):
+def test_upload_dir_contents(logged_in_query_user_with_existing_config, CONSTANTS, fixtures_dir):
     """Test upload all files in a directory using a glob pattern."""
     files = [x for x in fixtures_dir.glob("*") if x.is_file()]  # does not get subdirs
 
@@ -353,7 +354,7 @@ def test_upload_dir_contents(logged_in_edit_user_with_existing_config, CONSTANTS
     ],
 )
 def test_upload_glob_patterns(
-    logged_in_edit_user_with_existing_config, CONSTANTS, tmp_path, glob_pattern_template, expected_file_names
+    logged_in_query_user_with_existing_config, CONSTANTS, tmp_path, glob_pattern_template, expected_file_names
 ):
     """Test that glob patterns are correctly expanded when specifying files to upload."""
     clean_project = CONSTANTS["CLEANED_PROJECT"]
@@ -379,7 +380,7 @@ def test_upload_glob_patterns(
         assert file_name in result.stdout
 
 
-def test_upload_recursive_flag_matches_subdirectories(logged_in_edit_user_with_existing_config, CONSTANTS, tmp_path):
+def test_upload_recursive_flag_matches_subdirectories(logged_in_query_user_with_existing_config, CONSTANTS, tmp_path):
     """Test that --recursive expands ** patterns into subdirectories."""
     clean_project = CONSTANTS["CLEANED_PROJECT"]
 
@@ -399,7 +400,7 @@ def test_upload_recursive_flag_matches_subdirectories(logged_in_edit_user_with_e
 
 
 def test_upload_without_recursive_does_not_match_subdirectories(
-    logged_in_edit_user_with_existing_config, CONSTANTS, tmp_path
+    logged_in_query_user_with_existing_config, CONSTANTS, tmp_path
 ):
     """Test that without --recursive, ** patterns do not descend into subdirectories."""
     clean_project = CONSTANTS["CLEANED_PROJECT"]
@@ -417,7 +418,7 @@ def test_upload_without_recursive_does_not_match_subdirectories(
     assert NO_UPLOAD_MATCHES_MSG in result.stdout
 
 
-def test_upload_duplicate_file_names_rejected(logged_in_edit_user_with_existing_config, CONSTANTS, tmp_path):
+def test_upload_duplicate_file_names_rejected(logged_in_query_user_with_existing_config, CONSTANTS, tmp_path):
     """Test that uploading two files with the same name from different directories raises an error."""
     clean_project = CONSTANTS["CLEANED_PROJECT"]
 
@@ -436,7 +437,7 @@ def test_upload_duplicate_file_names_rejected(logged_in_edit_user_with_existing_
     assert "data.tsv" in result.stdout
 
 
-def test_upload_recursive_duplicate_names_rejected(logged_in_edit_user_with_existing_config, CONSTANTS, tmp_path):
+def test_upload_recursive_duplicate_names_rejected(logged_in_query_user_with_existing_config, CONSTANTS, tmp_path):
     """Test that --recursive upload raises an error when subdirs contain files with the same name."""
     clean_project = CONSTANTS["CLEANED_PROJECT"]
 
@@ -455,7 +456,7 @@ def test_upload_recursive_duplicate_names_rejected(logged_in_edit_user_with_exis
 
 
 def test_upload_skip_existing_skips_already_uploaded_files(
-    logged_in_edit_user_with_existing_config, CONSTANTS, tmp_path
+    logged_in_query_user_with_existing_config, CONSTANTS, tmp_path
 ):
     """Test that --skip-existing skips files already in the project and uploads only new ones."""
     clean_project = CONSTANTS["CLEANED_PROJECT"]
@@ -493,7 +494,7 @@ def test_upload_skip_existing_skips_already_uploaded_files(
     assert "no files were uploaded" in result.stdout.lower()
 
 
-def test_upload_dry_run_shows_files_without_uploading(logged_in_edit_user_with_existing_config, CONSTANTS, tmp_path):
+def test_upload_dry_run_shows_files_without_uploading(logged_in_query_user_with_existing_config, CONSTANTS, tmp_path):
     """Test that --dry-run shows which files would be uploaded but does not actually upload them."""
     clean_project = CONSTANTS["CLEANED_PROJECT"]
 
@@ -516,7 +517,7 @@ def test_upload_dry_run_shows_files_without_uploading(logged_in_edit_user_with_e
 
 
 def test_upload_dry_run_with_skip_existing_shows_skipped_and_new(
-    logged_in_edit_user_with_existing_config, CONSTANTS, tmp_path
+    logged_in_query_user_with_existing_config, CONSTANTS, tmp_path
 ):
     """Test that --dry-run --skip-existing shows which files would be skipped vs uploaded."""
     clean_project = CONSTANTS["CLEANED_PROJECT"]
@@ -544,7 +545,7 @@ def test_upload_dry_run_with_skip_existing_shows_skipped_and_new(
     assert "new_dry.tsv" not in ls_result.stdout
 
 
-def test_reupload_same_file_fails(logged_in_edit_user_with_existing_config, CONSTANTS, fixtures_dir):
+def test_reupload_same_file_fails(logged_in_query_user_with_existing_config, CONSTANTS, fixtures_dir):
     """Test upload with safe mode on (default) works the first time, but fails on subsequent attempts."""
     file_name = CONSTANTS["FILES_TO_UPLOAD_DOWNLOAD"][0]
     file_path = f"{fixtures_dir}/{file_name}"
@@ -560,7 +561,7 @@ def test_reupload_same_file_fails(logged_in_edit_user_with_existing_config, CONS
 
 
 def test_reupload_of_same_file_with_safe_mode_off_works(
-    logged_in_edit_user_with_existing_config, CONSTANTS, fixtures_dir
+    logged_in_query_user_with_existing_config, CONSTANTS, fixtures_dir
 ):
     """Test upload with safe mode off works for reuploading the same file."""
     file_name = CONSTANTS["FILES_TO_UPLOAD_DOWNLOAD"][0]
@@ -574,7 +575,7 @@ def test_reupload_of_same_file_with_safe_mode_off_works(
     assert result.exit_code == 0
 
 
-def test_no_file_uploaded_if_some_duplicated(logged_in_edit_user_with_existing_config, CONSTANTS, fixtures_dir):
+def test_no_file_uploaded_if_some_duplicated(logged_in_query_user_with_existing_config, CONSTANTS, fixtures_dir):
     """
     Test that no files are uploaded with safe mode on (which is the default)
     if at least 1 of the files trying to be uploaded already exists in the project's bucket.
@@ -601,7 +602,7 @@ def test_no_file_uploaded_if_some_duplicated(logged_in_edit_user_with_existing_c
         assert file.name not in result.stdout, f"File {file.name} was uploaded when it shouldn't have been."
 
 
-def test_upload_nonexistent_files(logged_in_edit_user_with_existing_config, tmp_path):
+def test_upload_nonexistent_files(logged_in_query_user_with_existing_config, tmp_path):
     """
     Test that uploading nonexistent files fails with helpful error msg about which files do not exist
     """
@@ -653,7 +654,7 @@ def test_upload_nonexistent_files(logged_in_edit_user_with_existing_config, tmp_
     ],
 )
 def test_upload_non_supported_files(
-    logged_in_edit_user_with_existing_config, CONSTANTS, tmp_path, file_names, expected_error
+    logged_in_query_user_with_existing_config, CONSTANTS, tmp_path, file_names, expected_error
 ):
     """
     Tests that the upload command correctly handles
@@ -1253,6 +1254,45 @@ def test_restore_file_with_exact_key_match_among_similar_prefixes(
     )
     assert result.exit_code != 0
     assert "404" in result.stdout
+
+
+def test_read_user_file_permissions(logged_in_read_user_with_existing_config, CONSTANTS, tmp_path):
+    """Read role cannot upload or delete files."""
+    test_file = tmp_path / "test.tsv"
+    test_file.write_text("col1\tcol2\nval1\tval2")
+
+    result = runner.invoke(app, f"files upload {test_file} --project {CONSTANTS['CLEANED_PROJECT']}")
+    assert_divbase_403_permissions_error(result)
+
+    result = runner.invoke(app, f"files rm {test_file.name} --project {CONSTANTS['CLEANED_PROJECT']}")
+    assert_divbase_403_permissions_error(result)
+
+
+def test_query_user_file_permissions(logged_in_query_user_with_existing_config, CONSTANTS, tmp_path):
+    """Query role can upload files but cannot delete them."""
+    test_file = tmp_path / "test.tsv"
+    test_file.write_text("col1\tcol2\nval1\tval2")
+
+    result = runner.invoke(app, f"files upload {test_file} --project {CONSTANTS['CLEANED_PROJECT']}")
+    assert result.exit_code == 0
+    assert "successfully uploaded" in result.stdout.lower()
+
+    result = runner.invoke(app, f"files rm {test_file.name} --project {CONSTANTS['CLEANED_PROJECT']}")
+    assert_divbase_403_permissions_error(result)
+
+
+def test_edit_user_file_permissions(logged_in_edit_user_with_existing_config, CONSTANTS, tmp_path):
+    """Edit role can upload and delete files."""
+    test_file = tmp_path / "test_edit_perms.tsv"
+    test_file.write_text("col1\tcol2\nval1\tval2")
+    clean_project = CONSTANTS["CLEANED_PROJECT"]
+
+    result = runner.invoke(app, f"files upload {test_file} --project {clean_project}")
+    assert result.exit_code == 0
+    assert "successfully uploaded" in result.stdout.lower()
+
+    result = runner.invoke(app, f"files rm {test_file.name} --project {clean_project}")
+    assert result.exit_code == 0
 
 
 #### Slow tests designed to test pagination/batching logic in all relevant files cli commands. ####

--- a/tests/e2e_integration/cli_commands/test_personal_access_tokens.py
+++ b/tests/e2e_integration/cli_commands/test_personal_access_tokens.py
@@ -37,6 +37,7 @@ from divbase_cli.divbase_cli import app
 runner = CliRunner()
 
 READ_USER_EMAIL = "read@divbase.se"
+QUERY_USER_EMAIL = "query@divbase.se"
 EDIT_USER_EMAIL = "edit@divbase.se"
 MANAGE_USER_EMAIL = "manage@divbase.se"
 
@@ -224,7 +225,7 @@ def test_project_scoped_task_history_excluded_project_rejected(
 def test_read_role_pat_rejects_edit_level_action(
     CONSTANTS, logged_out_user_with_existing_config, pat_factory, project_map, monkeypatch
 ):
-    """A PAT capped at read role cannot submit a query (requires edit)."""
+    """A PAT capped at read role cannot submit a query (requires query role or higher)."""
     project = CONSTANTS["DEFAULT_PROJECT"]
     permissions = {
         "all_projects": False,
@@ -293,6 +294,42 @@ def test_pat_stored_via_add_pat_cmd_works(CONSTANTS, logged_out_user_with_existi
         # clean up the stored PAT so it doesn't interfere with other tests, even if above fails
         result = runner.invoke(app=app, args="auth rm-pat")
         assert result.exit_code == 0
+
+
+def test_read_role_pat_rejects_upload(
+    CONSTANTS, logged_out_user_with_existing_config, pat_factory, project_map, monkeypatch, tmp_path
+):
+    """A PAT capped at read role cannot upload files (requires query role or higher)."""
+    project = CONSTANTS["DEFAULT_PROJECT"]
+    permissions = {
+        "all_projects": False,
+        "projects": {str(project_map[project]): "read"},
+        "task_history": False,
+    }
+    raw_token = pat_factory(user_email=EDIT_USER_EMAIL, permissions=permissions)
+    monkeypatch.setattr(cli_settings, "DIVBASE_API_PAT", raw_token)
+
+    test_file = tmp_path / "test.tsv"
+    test_file.write_text("col1\tcol2\nval1\tval2")
+    result = runner.invoke(app, f"files upload {test_file} --project {project}")
+    assert_403_error(result)
+
+
+def test_query_role_pat_rejects_file_delete(
+    CONSTANTS, logged_out_user_with_existing_config, pat_factory, project_map, monkeypatch
+):
+    """A PAT capped at query role cannot delete files (requires edit role or higher)."""
+    project = CONSTANTS["DEFAULT_PROJECT"]
+    permissions = {
+        "all_projects": False,
+        "projects": {str(project_map[project]): "query"},
+        "task_history": False,
+    }
+    raw_token = pat_factory(user_email=EDIT_USER_EMAIL, permissions=permissions)
+    monkeypatch.setattr(cli_settings, "DIVBASE_API_PAT", raw_token)
+
+    result = runner.invoke(app, f"files rm file1.tsv --project {project}")
+    assert_403_error(result)
 
 
 def test_pat_does_not_work_on_frontend_endpoints(CONSTANTS, logged_out_user_with_existing_config, pat_factory):

--- a/tests/e2e_integration/cli_commands/test_query_cli.py
+++ b/tests/e2e_integration/cli_commands/test_query_cli.py
@@ -22,6 +22,7 @@ from divbase_cli.divbase_cli import app
 from divbase_lib.divbase_constants import QUERY_RESULTS_FILE_PREFIX
 from divbase_lib.s3_checksums import MD5CheckSumFormat, calculate_md5_checksum
 from tests.conftest import REGRESSION_GUARD_PREFIX
+from tests.e2e_integration.cli_commands.conftest import assert_divbase_403_permissions_error
 
 runner = CliRunner()
 
@@ -154,6 +155,16 @@ def _checksum_vcf_skip_double_hash_headers(vcf_gz_file: Path, tmp_path: Path) ->
         file_path=normalized_file,
         output_format=MD5CheckSumFormat.HEX,
     )
+
+
+def test_read_user_query_permissions(logged_in_read_user_with_existing_config, CONSTANTS):
+    """Read role cannot submit VCF queries."""
+    project = CONSTANTS["QUERY_PROJECT"]
+    result = runner.invoke(app, f"query vcf --all-samples --command 'view -r 21:15000000-25000000' --project {project}")
+    assert_divbase_403_permissions_error(result)
+
+    result = runner.invoke(app, f"query tsv 'Area:West of Ireland,Northern Portugal;Sex:F' --project {project}")
+    assert_divbase_403_permissions_error(result)
 
 
 class TestQueryTSVSuccess:

--- a/tests/e2e_integration/cli_commands/test_task_history_cli.py
+++ b/tests/e2e_integration/cli_commands/test_task_history_cli.py
@@ -328,14 +328,6 @@ def test_read_user_cannot_see_task_history(CONSTANTS, logged_in_read_user_with_e
     """
     Integration test that read user cannot access the task history, since they cannot submit tasks.
     """
-
-    # Without --project flag, error is about being an only-Read user
-    result_history = runner.invoke(app, "task-history user")
-    assert result_history.exit_code == 1
-    assert "authorization_error" in str(result_history.exception)
-    assert "You do not have access view to task history" in str(result_history.exception)
-
-    # With --project flag, error is about access to this particular project
     project_name = CONSTANTS["QUERY_PROJECT"]
     result_history = runner.invoke(app, f"task-history user --project {project_name}")
     assert result_history.exit_code == 1

--- a/tests/e2e_integration/cli_commands/test_task_history_cli.py
+++ b/tests/e2e_integration/cli_commands/test_task_history_cli.py
@@ -332,9 +332,8 @@ def test_read_user_cannot_see_task_history(CONSTANTS, logged_in_read_user_with_e
     result_history = runner.invoke(app, f"task-history user --project {project_name}")
     assert result_history.exit_code == 1
     assert "authorization_error" in str(result_history.exception)
-    assert "Project not found or you don't have permission to view task history from this project" in str(
-        result_history.exception
-    )
+    assert "You don't have permission to view task history for this project" in str(result_history.exception)
+    assert "You need at least 'QUERY' level permissions for this" in str(result_history.exception)
 
 
 def test_edit_user_cannot_see_task_history_for_project_not_member_of(

--- a/tests/e2e_integration/cli_commands/test_version_cli.py
+++ b/tests/e2e_integration/cli_commands/test_version_cli.py
@@ -8,6 +8,7 @@ from typer.testing import CliRunner
 
 from divbase_cli.cli_exceptions import DivBaseAPIError
 from divbase_cli.divbase_cli import app
+from tests.e2e_integration.cli_commands.conftest import assert_divbase_403_permissions_error
 
 runner = CliRunner()
 
@@ -28,15 +29,26 @@ def clean_versions(db_session_sync):
     yield
 
 
-def test_add_version(logged_in_edit_user_with_existing_config):
-    command = f"version add {VERSION_1_NAME}"
-    result = runner.invoke(app, command)
+def test_read_user_cannot_add_or_rm_version(logged_in_read_user_with_existing_config):
+    """Read role cannot add or delete project versions."""
+    result = runner.invoke(app, f"version add {VERSION_1_NAME}")
+    assert_divbase_403_permissions_error(result)
 
+    result = runner.invoke(app, f"version rm {VERSION_1_NAME}")
+    assert_divbase_403_permissions_error(result)
+
+
+def test_query_user_cannot_rm_a_version(logged_in_query_user_with_existing_config):
+    """Query role can add project versions but cannot delete them."""
+    result = runner.invoke(app, f"version add {VERSION_1_NAME}")
     assert result.exit_code == 0
     assert f"New version: '{VERSION_1_NAME}'" in result.stdout
 
+    result = runner.invoke(app, f"version rm {VERSION_1_NAME}")
+    assert_divbase_403_permissions_error(result)
 
-def test_add_version_with_description(logged_in_edit_user_with_existing_config):
+
+def test_add_version_with_description(logged_in_query_user_with_existing_config):
     description = "Initial release"
     command = f'version add {VERSION_1_NAME} --description "{description}"'
     result = runner.invoke(app, command)
@@ -50,7 +62,7 @@ def test_add_version_with_description(logged_in_edit_user_with_existing_config):
     assert description in list_result.stdout
 
 
-def test_add_multiple_versions(logged_in_edit_user_with_existing_config):
+def test_add_multiple_versions(logged_in_query_user_with_existing_config):
     versions = [VERSION_1_NAME, VERSION_2_NAME, VERSION_3_NAME]
     for version in versions:
         command = f"version add {version}"
@@ -65,7 +77,7 @@ def test_add_multiple_versions(logged_in_edit_user_with_existing_config):
         assert version in result.stdout
 
 
-def test_attempt_add_version_that_already_exists_fails(logged_in_edit_user_with_existing_config):
+def test_attempt_add_version_that_already_exists_fails(logged_in_query_user_with_existing_config):
     command = "version add v1.0.0"
 
     result = runner.invoke(app, command)
@@ -78,7 +90,7 @@ def test_attempt_add_version_that_already_exists_fails(logged_in_edit_user_with_
     assert result.exception.status_code == 400
 
 
-def test_list_versions(logged_in_edit_user_with_existing_config):
+def test_list_versions(logged_in_query_user_with_existing_config):
     runner.invoke(app, f"version add {VERSION_1_NAME}")
     runner.invoke(app, f"version add {VERSION_2_NAME}")
 
@@ -91,7 +103,10 @@ def test_list_versions(logged_in_edit_user_with_existing_config):
 
 
 def test_list_versions_with_and_without_include_deleted_flag(logged_in_edit_user_with_existing_config):
-    """Test that deleted versions only show up when include_deleted flag is used"""
+    """
+    Test that deleted versions only show up when include_deleted flag is used
+    (rm requires edit user permissions)
+    """
     runner.invoke(app, f"version add {VERSION_1_NAME}")
     runner.invoke(app, f"version add {VERSION_2_NAME}")
     runner.invoke(app, f"version rm {VERSION_1_NAME}")
@@ -107,7 +122,7 @@ def test_list_versions_with_and_without_include_deleted_flag(logged_in_edit_user
     assert VERSION_2_NAME in result.stdout
 
 
-def test_list_versions_for_empty_project(logged_in_edit_user_with_existing_config):
+def test_list_versions_for_empty_project(logged_in_query_user_with_existing_config):
     """Test that list version works fine if no versions exist"""
     result = runner.invoke(app, "version ls")
     assert result.exit_code == 0

--- a/tests/e2e_integration/helpers/setup_test_data.py
+++ b/tests/e2e_integration/helpers/setup_test_data.py
@@ -28,6 +28,12 @@ TEST_USERS = {
         "organisation": "Uppsala University",
         "organisation_role": "Postdoctoral Researcher",
     },
+    "query user": {
+        "email": "query@divbase.se",
+        "password": "badpassword",
+        "organisation": "Karlstad University",
+        "organisation_role": "Student",
+    },
     "edit user": {
         "email": "edit@divbase.se",
         "password": "badpassword",
@@ -153,6 +159,7 @@ TEST_PROJECTS = {
 
 USER_ROLES = {
     "read@divbase.se": "read",
+    "query@divbase.se": "query",
     "edit@divbase.se": "edit",
     "manage@divbase.se": "manage",
 }


### PR DESCRIPTION
This idea originally came from the test user group feedback. Basically: have 1 more `ProjectRoles` that sits in between READ and EDIT roles, named QUERY. The QUERY role can upload files and run queries and run dimensions update. It cannot rm files or rm/update project versions unlike the EDIT role.

The permissions for each role is fully described on the `docs/user-guides/account-management.md` page and summarized on the website's project detail page (with a link to docs site) and in the modal when a project manager adds a new member and set the new members permissions.  

### Summary of changes:
- updates api routes guards accordingly to match the new permissions. 
- Frontend forms etc.. include the new role and display the query role both when managing members and when setting the scope of a PAT. 
- updates docs to include query role and the guide on what each role can do.  
- Added some e2e tests to help validate what each role can do, and also modified some existing tests to use the minimum role that can possibly do the task as a way to improve the validation (e.g. if the tests is for uploading a file, let a query user do it, not an edit user).  
- I modified some of the `AuthorizationError()` messages raised in the api routes to (1) remove "project does not exist" as part of the error message because user must be a member of the project in order to reach that stage otherwise the `Depends(get_project_member)` would have already raised (and said either project does not exist or you are not a member). (2) I also included what role would be needed to do the operation as perhaps useful (didn't do it for READ required operations though as that is the min level). 


### Note on the db migration:
As enums are little special in postgres, the migration script essentially (1) stringyfies the roles, deletes the enum and then recreates the new enum and then casts the strings back into the enum. This worked nicely in local dev (both up and downgrade with a query user created before doing the downgrade). 
I will test this migration on the dev cluster to be sure though. 

### Plan:
- Review from the :robot: 
- test deploy on dev cluster
- open for review 