### PR TITLE
SQ-917: One dimensions update task at a time per project

### DIFF
--- a/packages/divbase-api/src/divbase_api/crud/vcf_dimensions.py
+++ b/packages/divbase-api/src/divbase_api/crud/vcf_dimensions.py
@@ -141,7 +141,7 @@ async def check_no_dimensions_update_task_already_in_progress(
     """
     ongoing_dimensions_tasks_subq = (
         select(CeleryTaskMeta.task_id)
-        .where(CeleryTaskMeta.status.in_(["PENDING", "STARTED"]))
+        .where(CeleryTaskMeta.status.in_(["PENDING", "STARTED", "RETRY"]))
         .where(CeleryTaskMeta.name == "tasks.update_vcf_dimensions_task")
         .subquery()
     )

--- a/packages/divbase-api/src/divbase_api/crud/vcf_dimensions.py
+++ b/packages/divbase-api/src/divbase_api/crud/vcf_dimensions.py
@@ -11,6 +11,8 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from divbase_api.exceptions import DimensionsUpdateAlreadyInProcessError
+from divbase_api.models.task_history import CeleryTaskMeta, TaskHistoryDB
 from divbase_api.models.vcf_dimensions import SkippedVCFDB, VCFMetadataDB, VCFMetadataSamplesDB, VCFMetadataScaffoldsDB
 
 logger = structlog.get_logger(__name__)
@@ -126,3 +128,36 @@ async def get_unique_vcf_files_by_project_async(db: AsyncSession, project_id: in
     for file_name, version_id in rows:
         unique_vcf_files.append({"vcf_file_s3_key": file_name, "s3_version_id": version_id})
     return unique_vcf_files
+
+
+async def check_no_dimensions_update_task_already_in_progress(
+    db: AsyncSession, project_id: int, project_name: str
+) -> None:
+    """
+    Check that there is not already a dimensions update job in process for the given project and raise if so.
+    This check includes jobs that are both queued and running.
+
+    There only needs to be one dimensions update job run at a time per project, otherwise it is just waited compute + bandwidth.
+    """
+    ongoing_dimensions_tasks_subq = (
+        select(CeleryTaskMeta.task_id)
+        .where(CeleryTaskMeta.status.in_(["PENDING", "STARTED"]))
+        .where(CeleryTaskMeta.name == "tasks.update_vcf_dimensions_task")
+        .subquery()
+    )
+
+    # the .id is the user facing id (aka rolling int) and not the celery internal uuid which is .task_id
+    stmt = (
+        select(TaskHistoryDB.id)
+        .join(ongoing_dimensions_tasks_subq, TaskHistoryDB.task_id == ongoing_dimensions_tasks_subq.c.task_id)
+        .where(TaskHistoryDB.project_id == project_id)
+    )
+    result = await db.execute(stmt)
+    # NOTE: don't use one_or_none() here since we can't guarantee there is only one ongoing task.
+    ongoing_task_id = result.first()
+
+    if ongoing_task_id is not None:
+        raise DimensionsUpdateAlreadyInProcessError(
+            project_name=project_name,
+            ongoing_task_id=ongoing_task_id[0],
+        )

--- a/packages/divbase-api/src/divbase_api/crud/vcf_dimensions.py
+++ b/packages/divbase-api/src/divbase_api/crud/vcf_dimensions.py
@@ -137,7 +137,7 @@ async def check_no_dimensions_update_task_already_in_progress(
     Check that there is not already a dimensions update job in process for the given project and raise if so.
     This check includes jobs that are both queued and running.
 
-    There only needs to be one dimensions update job run at a time per project, otherwise it is just waited compute + bandwidth.
+    There only needs to be one dimensions update job run at a time per project, otherwise it is just wasted compute + bandwidth.
     """
     ongoing_dimensions_tasks_subq = (
         select(CeleryTaskMeta.task_id)

--- a/packages/divbase-api/src/divbase_api/exception_handlers.py
+++ b/packages/divbase-api/src/divbase_api/exception_handlers.py
@@ -20,6 +20,7 @@ from divbase_api.deps import _authenticate_frontend_user_from_tokens
 from divbase_api.exceptions import (
     AuthenticationError,
     AuthorizationError,
+    DimensionsUpdateAlreadyInProcessError,
     DownloadedFileChecksumMismatchError,
     ObjectDoesNotExistError,
     PATDuplicateNameError,
@@ -410,6 +411,24 @@ async def vcf_dimensions_entry_missing_error_handler(request: Request, exc: VCFD
         return await render_error_page(request, exc.message, status_code=exc.status_code)
 
 
+async def dimensions_update_already_in_process_error_handler(
+    request: Request, exc: DimensionsUpdateAlreadyInProcessError
+):
+    logger.info(
+        f"Dimensions update already in process error for {request.method} {request.url.path}: {exc.message}",
+        exc_info=False,
+    )
+
+    if is_api_request(request):
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"detail": exc.message, "type": "dimensions_update_task_already_in_process_error"},
+            headers=exc.headers,
+        )
+    else:
+        return await render_error_page(request, exc.message, status_code=exc.status_code)
+
+
 async def task_not_found_in_backend_error_handler(request: Request, exc: TaskNotFoundInBackendError):
     logger.warning(
         f"Task ID not found in results backend for {request.method} {request.url.path}: {exc.message}", exc_info=True
@@ -489,6 +508,10 @@ def register_exception_handlers(app: FastAPI) -> None:
     app.add_exception_handler(ProjectVersionSoftDeletedError, project_version_soft_deleted_error_handler)  # type: ignore
     app.add_exception_handler(RequestValidationError, request_validation_error_handler)  # type: ignore
     app.add_exception_handler(VCFDimensionsEntryMissingError, vcf_dimensions_entry_missing_error_handler)  # type: ignore
+    app.add_exception_handler(
+        DimensionsUpdateAlreadyInProcessError,
+        dimensions_update_already_in_process_error_handler,  # type: ignore
+    )
     app.add_exception_handler(TaskNotFoundInBackendError, task_not_found_in_backend_error_handler)  # type: ignore
     app.add_exception_handler(DownloadedFileChecksumMismatchError, downloaded_file_checksum_mismatch_error_handler)  # type: ignore
     app.add_exception_handler(ObjectDoesNotExistError, object_does_not_exist_error_handler)  # type: ignore

--- a/packages/divbase-api/src/divbase_api/exceptions.py
+++ b/packages/divbase-api/src/divbase_api/exceptions.py
@@ -124,6 +124,18 @@ class VCFDimensionsEntryMissingError(DivBaseAPIException):
         super().__init__(message, status_code=status.HTTP_404_NOT_FOUND)
 
 
+class DimensionsUpdateAlreadyInProcessError(DivBaseAPIException):
+    """Raised when a user tries to queue a new VCF dimensions update task for a project that already has an queued or running update task."""
+
+    def __init__(self, project_name: str, ongoing_task_id: int):
+        message = (
+            f"A VCF dimensions update task (with id: {ongoing_task_id}) is already in process for the project '{project_name}'. \n"
+            f"Only one dimensions update task can be run at a time. \n"
+            "The dimensions update task will incorporate files uploaded/modified during runtime, so there is no need to start another update task while this one is in progress."
+        )
+        super().__init__(message=message, status_code=status.HTTP_409_CONFLICT)
+
+
 class TaskNotFoundInBackendError(DivBaseAPIException):
     """Raised when a task ID exists in the task_history table in the database but not in the results backend."""
 

--- a/packages/divbase-api/src/divbase_api/exceptions.py
+++ b/packages/divbase-api/src/divbase_api/exceptions.py
@@ -125,7 +125,7 @@ class VCFDimensionsEntryMissingError(DivBaseAPIException):
 
 
 class DimensionsUpdateAlreadyInProcessError(DivBaseAPIException):
-    """Raised when a user tries to queue a new VCF dimensions update task for a project that already has an queued or running update task."""
+    """Raised when a user tries to queue a new VCF dimensions update task for a project that already has a queued or running update task."""
 
     def __init__(self, project_name: str, ongoing_task_id: int):
         message = (

--- a/packages/divbase-api/src/divbase_api/routes/vcf_dimensions.py
+++ b/packages/divbase-api/src/divbase_api/routes/vcf_dimensions.py
@@ -10,6 +10,7 @@ from divbase_api.crud.projects import has_required_role
 from divbase_api.crud.queue_status import check_queue_closed_for_new_tasks
 from divbase_api.crud.task_history import create_task_history_entry
 from divbase_api.crud.vcf_dimensions import (
+    check_no_dimensions_update_task_already_in_progress,
     get_skipped_vcfs_by_project_async,
     get_unique_samples_by_project_async,
     get_unique_scaffolds_by_project_async,
@@ -87,7 +88,8 @@ async def update_vcf_dimensions_endpoint(
     db: AsyncSession = Depends(get_db),
 ) -> int:
     """
-    Update the VCF dimensions files for the specified project
+    Update the VCF dimensions files for the specified project.
+    If an existing dimensions update task is already in process or queued for the project, you will be prevented from submitting another update task.
     """
     project, current_user, role = project_and_user_and_role
 
@@ -96,6 +98,7 @@ async def update_vcf_dimensions_endpoint(
             "You don't have permission to update VCF dimensions, you need at least 'QUERY' level permissions."
         )
     await check_queue_closed_for_new_tasks(db=db, is_admin=current_user.is_admin)
+    await check_no_dimensions_update_task_already_in_progress(db=db, project_id=project.id, project_name=project.name)
 
     task_kwargs = DimensionUpdateKwargs(
         bucket_name=project.bucket_name,

--- a/tests/e2e_integration/cli_commands/test_dimensions_cli.py
+++ b/tests/e2e_integration/cli_commands/test_dimensions_cli.py
@@ -149,7 +149,7 @@ def test_dimensions_update_blocked_when_task_already_in_progress_for_same_projec
     logged_in_edit_user_with_existing_config,
     status,
 ):
-    """Dimensions update should be rejected if a PENDING or STARTED task already exists for the same project."""
+    """Dimensions update should be rejected if a PENDING/STARTED/RETRY task already exists for the same project."""
     project_name = CONSTANTS["CLEANED_PROJECT"]
     project_id = project_map[project_name]
 

--- a/tests/e2e_integration/cli_commands/test_dimensions_cli.py
+++ b/tests/e2e_integration/cli_commands/test_dimensions_cli.py
@@ -141,7 +141,7 @@ def test_read_user_cannot_trigger_dimensions_update(logged_in_read_user_with_exi
     assert "403" in str(result.exception)
 
 
-@pytest.mark.parametrize("status", ["PENDING", "STARTED"])
+@pytest.mark.parametrize("status", ["PENDING", "STARTED", "RETRY"])
 def test_dimensions_update_blocked_when_task_already_in_progress_for_same_project(
     CONSTANTS,
     project_map,

--- a/tests/e2e_integration/cli_commands/test_dimensions_cli.py
+++ b/tests/e2e_integration/cli_commands/test_dimensions_cli.py
@@ -6,13 +6,15 @@ import ast
 import gzip
 import os
 import re
+import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select
 from typer.testing import CliRunner
 
+from divbase_api.models.task_history import CeleryTaskMeta, TaskHistoryDB
 from divbase_api.models.vcf_dimensions import VCFMetadataDB, VCFMetadataSamplesDB, VCFMetadataScaffoldsDB
 from divbase_api.services.s3_client import create_s3_file_manager
 from divbase_api.worker.crud_dimensions import (
@@ -35,10 +37,31 @@ from tests.conftest import REGRESSION_GUARD_PREFIX
 
 runner = CliRunner()
 
+DIMENSIONS_UPDATE_TASK_NAME = "tasks.update_vcf_dimensions_task"
+
 
 @pytest.fixture(autouse=True, scope="function")
 def auto_clean_dimensions_entries_for_all_projects(clean_all_projects_dimensions):
     """Enable auto-cleanup of dimensions entries for all tests in this test file."""
+    yield
+
+
+@pytest.fixture(autouse=True, scope="function")
+def clean_dimensions_update_task_history(db_session_sync):
+    """
+    Delete all TaskHistoryDB + CeleryTaskMeta rows for dimensions update tasks before each test.
+
+    This is to avoid test pollution, a task dispatched by a previous test can be in PENDING/STARTED state
+    and cause a guard in the router to raise a 409.
+    The guard prevents more than 1 dimensions update task from running at a time in a given project.
+    """
+    stmt = select(CeleryTaskMeta.task_id).where(CeleryTaskMeta.name == DIMENSIONS_UPDATE_TASK_NAME)
+    result = db_session_sync.execute(stmt)
+    task_ids = result.scalars().all()
+    if task_ids:
+        db_session_sync.execute(delete(CeleryTaskMeta).where(CeleryTaskMeta.task_id.in_(task_ids)))
+        db_session_sync.execute(delete(TaskHistoryDB).where(TaskHistoryDB.task_id.in_(task_ids)))
+        db_session_sync.commit()
     yield
 
 
@@ -71,6 +94,21 @@ def _read_text_from_gz_file(path: os.PathLike) -> str:
         return f.read()
 
 
+def _insert_fake_dimensions_tasks(
+    db, project_id: int, status: str, task_name: str = DIMENSIONS_UPDATE_TASK_NAME
+) -> None:
+    """
+    Insert a TaskHistoryDB + CeleryTaskMeta row to simulate a dimensions update task in a given state.
+    Entries autocleaned after test by the clean_dimensions_update_task_history fixture.
+    """
+    task_id = str(uuid.uuid4())
+    db.add(TaskHistoryDB(task_id=task_id, project_id=project_id, user_id=1))
+    # as this is a celery managed table, sqlalchemy can't autoincrement the id, so we figure out the biggest id and add 1.
+    next_id = db.execute(select(func.coalesce(func.max(CeleryTaskMeta.id), 0) + 1)).scalar()
+    db.add(CeleryTaskMeta(id=next_id, task_id=task_id, status=status, name=task_name))
+    db.commit()
+
+
 def test_update_vcf_dimensions_task_directly(
     CONSTANTS,
     run_update_dimensions,
@@ -101,6 +139,79 @@ def test_read_user_cannot_trigger_dimensions_update(logged_in_read_user_with_exi
     assert result.exit_code != 0
     assert isinstance(result.exception, DivBaseAPIError)
     assert "403" in str(result.exception)
+
+
+@pytest.mark.parametrize("status", ["PENDING", "STARTED"])
+def test_dimensions_update_blocked_when_task_already_in_progress_for_same_project(
+    CONSTANTS,
+    project_map,
+    db_session_sync,
+    logged_in_edit_user_with_existing_config,
+    status,
+):
+    """Dimensions update should be rejected if a PENDING or STARTED task already exists for the same project."""
+    project_name = CONSTANTS["CLEANED_PROJECT"]
+    project_id = project_map[project_name]
+
+    _insert_fake_dimensions_tasks(db=db_session_sync, project_id=project_id, status=status)
+    result = runner.invoke(app, f"dimensions update --project {project_name}")
+    assert result.exit_code != 0
+    assert isinstance(result.exception, DivBaseAPIError)
+    assert "409" in str(result.exception)
+    assert "dimensions_update_task_already_in_process_error" in str(result.exception)
+
+
+def test_dimensions_update_allowed_when_ongoing_task_is_for_different_project(
+    CONSTANTS,
+    project_map,
+    db_session_sync,
+    logged_in_edit_user_with_existing_config,
+):
+    """Dimensions update job should be allowed even if there is a PENDING/STARTED task for a different project."""
+    target_project_name = CONSTANTS["CLEANED_PROJECT"]
+    other_project_name = CONSTANTS["NON_DEFAULT_PROJECT"]
+    other_project_id = project_map[other_project_name]
+
+    _insert_fake_dimensions_tasks(db=db_session_sync, project_id=other_project_id, status="PENDING")
+    _insert_fake_dimensions_tasks(db=db_session_sync, project_id=other_project_id, status="STARTED")
+    result = runner.invoke(app, f"dimensions update --project {target_project_name}")
+    assert result.exit_code == 0
+
+
+def test_dimensions_update_allowed_when_completed_task_exists_for_same_project(
+    CONSTANTS,
+    project_map,
+    db_session_sync,
+    logged_in_edit_user_with_existing_config,
+):
+    """Can run a dimensions update task even if a SUCCESS or FAILED task exists for the project."""
+    project_name = CONSTANTS["CLEANED_PROJECT"]
+    project_id = project_map[project_name]
+
+    _insert_fake_dimensions_tasks(db=db_session_sync, project_id=project_id, status="SUCCESS")
+    _insert_fake_dimensions_tasks(db=db_session_sync, project_id=project_id, status="FAILED")
+    result = runner.invoke(app, f"dimensions update --project {project_name}")
+    assert result.exit_code == 0
+
+
+def test_dimensions_update_allowed_when_pending_task_is_different_task_type(
+    CONSTANTS,
+    project_map,
+    db_session_sync,
+    logged_in_edit_user_with_existing_config,
+):
+    """Dimensions update can run even if there is a PENDING/STARTED task in the same project but with a different task name."""
+    project_name = CONSTANTS["CLEANED_PROJECT"]
+    project_id = project_map[project_name]
+
+    _insert_fake_dimensions_tasks(
+        db=db_session_sync, project_id=project_id, status="PENDING", task_name="tasks.other_task"
+    )
+    _insert_fake_dimensions_tasks(
+        db=db_session_sync, project_id=project_id, status="STARTED", task_name="tasks.other_task"
+    )
+    result = runner.invoke(app, f"dimensions update --project {project_name}")
+    assert result.exit_code == 0
 
 
 def test_show_vcf_dimensions_task(


### PR DESCRIPTION
### why
- It's a waste of compute/bandwidth to run more than 1 dimensions update task at a time (for the same project), as they will essentially obtain the same information.
- This PR prevents duplicate submissions in all but the rare case where two users submit the `divbase-cli dimensions update` command  (to the same project) within the same second/fraction of a second. If that does happen it is
not harmful to the project/db state, just wasted compute.

### implementation summary
- The guard is added to the api route. If a dimensions update task is already queued/running for a given project, an attempt to make a new one for the same project will receive a DimensionsUpdateAlreadyInProcessError, with error message telling the user the task id of the in progress dimensions update command. 
- E2E tests added to validate both the guard works correctly and doesn't incorrectly block tasks when e.g., a dimensions update for a different project is running or if e.g. dimensions update task is in completed state.

